### PR TITLE
T1 corrective: lineage currentness + collector digest canonicalization (#162)

### DIFF
--- a/paperforge/architecture_audit/collectors/common.py
+++ b/paperforge/architecture_audit/collectors/common.py
@@ -85,12 +85,23 @@ def discover_sources(root: Path, suffixes: tuple[str, ...], *, exclude_tests: bo
     return out
 
 
+def canonical_source_bytes(data: bytes) -> bytes:
+    """Canonical source bytes for content digests: CRLF → LF.
+
+    Windows checkout (CRLF) vs CI checkout (LF) must not produce different
+    fingerprints — the digest means content, not line-ending style.  This is
+    the single canonicalization the golden verifier mirrors.
+    """
+    return data.replace(b"\r\n", b"\n")
+
+
 def sha256_file(path: Path) -> str:
-    """Content digest of a source file."""
+    """Content digest of a source file (canonicalized, see
+    :func:`canonical_source_bytes`)."""
     digest = hashlib.sha256()
     with path.open("rb") as handle:
         for chunk in iter(lambda: handle.read(1 << 16), b""):
-            digest.update(chunk)
+            digest.update(canonical_source_bytes(chunk))
     return "sha256:" + digest.hexdigest()
 
 

--- a/paperforge/architecture_audit/collectors/ts_collect.js
+++ b/paperforge/architecture_audit/collectors/ts_collect.js
@@ -167,7 +167,7 @@ function main() {
     const rel = posix(path.relative(rootDir, file));
     let source;
     try {
-      source = fs.readFileSync(file, "utf8");
+      source = fs.readFileSync(file, "utf8").replace(/\r\n/g, "\n");
     } catch (err) {
       parseErrors.push(`${rel}: ${err.message}`);
       continue;

--- a/paperforge/lineage.py
+++ b/paperforge/lineage.py
@@ -256,14 +256,20 @@ def probe_lineage(vault: Path) -> dict[str, Any]:
         )
         embedding_identity = _current_embedding_identity(conn, vault)
         for key in keys:
-            ocr_state = _probe_ocr_state(
+            # #162 corrective: each layer observes (state, identity) so the
+            # NEXT layer can detect a freshly published upstream identity —
+            # enum-only propagation misses the normal publish transitions.
+            ocr_state, ocr_identity = _probe_ocr_state(
                 (ocr_root / key) if ocr_root is not None else None
             )
-            retrieval_state = _probe_retrieval_state(conn, key, ocr_state)
+            retrieval_state, retrieval_identity = _probe_retrieval_state(
+                conn, key, ocr_state, ocr_identity
+            )
             vector_state = _probe_vector_state(
                 conn,
                 key,
                 retrieval_state,
+                retrieval_identity,
                 embedding_identity,
                 has_lineage_table,
             )
@@ -326,59 +332,82 @@ def _paper_keys(vault: Path, db_path: Path) -> list[str]:
     return sorted(keys)
 
 
-def _probe_ocr_state(paper_dir: Path | None) -> str:
-    """OCR: current | stale | missing | unknown.
+def _probe_ocr_state(paper_dir: Path | None) -> tuple[str, str | None]:
+    """(state, published_ocr_identity) — current | stale | missing | unknown.
 
     Pending publication marker → unknown (#126 semantics).  Published
-    result-hash equals the artifact hash → current; differs → stale.
+    result-hash equals the artifact hash → current; differs → stale.  The
+    identity is the published result hash whenever readable.
     """
     if paper_dir is None or not paper_dir.exists():
-        return "missing"
+        return "missing", None
     if not (paper_dir / "structure" / "blocks.structured.jsonl").exists():
-        return "missing"
+        return "missing", None
     if has_result_hash_pending(paper_dir):
-        return "unknown"
+        return "unknown", None
     hash_file = paper_dir / "index" / "result-hash.txt"
     if not hash_file.exists():
-        return "unknown"
+        return "unknown", None
     try:
         stored = hash_file.read_text(encoding="utf-8").strip()
     except OSError:
-        return "unknown"
+        return "unknown", None
     current = compute_ocr_result_hash(paper_dir)
     if current is None:
-        return "unknown"
-    return "current" if stored == current else "stale"
+        return "unknown", None
+    if stored != current:
+        return "stale", stored
+    return "current", stored
 
 
 def _probe_retrieval_state(
-    conn: sqlite3.Connection, key: str, ocr_state: str
-) -> str:
-    """Retrieval: current | stale | missing | unknown."""
+    conn: sqlite3.Connection,
+    key: str,
+    ocr_state: str,
+    current_ocr_identity: str | None,
+) -> tuple[str, str | None]:
+    """(state, current_retrieval_identity) — current | stale | missing | unknown.
+
+    The manifest is current only when ALL of:
+      - it embeds the CURRENT published OCR identity (a normal OCR publish
+        makes the old retrieval stale, #162 corrective P0-1);
+      - it was built under the CURRENT retrieval policy (a policy bump is a
+        global desired-state change, #159 §2.1);
+      - its stored identity equals its own recomputed identity.
+    """
     if ocr_state == "missing":
-        return "missing"
+        return "missing", None
     if ocr_state == "unknown":
-        return "unknown"
+        return "unknown", None
+    if ocr_state == "stale":
+        # Artifacts changed since the last publish — the published identity
+        # is no longer materialized; the retrieval built on it is stale too.
+        return "stale", None
     row = conn.execute(
         "SELECT value FROM meta WHERE key = ?", (f"manifest:{key}",)
     ).fetchone()
     if not row:
-        return "missing"
+        return "missing", None
     try:
         manifest = json.loads(row[0])
     except (TypeError, ValueError):
-        return "unknown"
+        return "unknown", None
     stored = manifest.get("retrieval_identity")
     recomputed = retrieval_identity_from_manifest(manifest)
     if not stored or not recomputed:
         # Legacy manifest without a retrieval identity → unknown, never stale.
-        return "unknown"
+        return "unknown", None
+    if manifest.get("ocr_result_hash") != current_ocr_identity:
+        # Fresh OCR identity published since this manifest was built.
+        return "stale", None
+    from paperforge.retrieval.manifest import RETRIEVAL_POLICY_VERSION
+
+    if manifest.get("retrieval_policy_version") != RETRIEVAL_POLICY_VERSION:
+        # Global retrieval policy moved; this manifest predates it.
+        return "stale", None
     if stored != recomputed:
-        return "stale"
-    if ocr_state == "stale":
-        # Upstream OCR changed; retrieval was built from the old hash.
-        return "stale"
-    return "current"
+        return "stale", None
+    return "current", recomputed
 
 
 def _current_embedding_identity(
@@ -416,6 +445,7 @@ def _probe_vector_state(
     conn: sqlite3.Connection,
     key: str,
     retrieval_state: str,
+    current_retrieval_identity: str | None,
     embedding_identity: str | None,
     has_lineage_table: bool,
 ) -> str:
@@ -449,13 +479,17 @@ def _probe_vector_state(
     stored_identity, derived_from, stored_embedding = row
     if retrieval_state != "current":
         return "unknown" if retrieval_state == "unknown" else "stale"
-    if not embedding_identity:
+    if not embedding_identity or not current_retrieval_identity:
         return "unknown"
+    if derived_from != current_retrieval_identity:
+        # A NEW retrieval identity was published since these vectors were
+        # built (memory.build) — the old vectors are stale (#162 P0-2).
+        return "stale"
     if stored_embedding != embedding_identity:
         # Substrate identity changed (model/endpoint/dimension) since build.
         return "stale"
     expected = compute_vector_identity(
-        retrieval_identity=derived_from,
+        retrieval_identity=current_retrieval_identity,
         embedding_identity=embedding_identity,
     )
     if stored_identity != expected:

--- a/tests/test_lineage.py
+++ b/tests/test_lineage.py
@@ -380,6 +380,70 @@ class TestProbeLineage:
         # KEY2 has vectors but no lineage row → unknown, never stale.
         assert payload["papers"]["KEY2"]["vector"] == "unknown"
 
+    def test_new_published_ocr_identity_marks_retrieval_and_vector_stale(self, tmp_path: Path) -> None:
+        """#162 P0-1: a NORMAL OCR publish (artifacts + result-hash both
+        updated) must make the old retrieval and vector stale — the manifest
+        embeds the old OCR identity."""
+        vault = _make_vault(tmp_path)
+        ocr_dir = vault / "99_System" / "PaperForge" / "ocr" / "KEY1"
+        from paperforge.worker.ocr_hash import publish_ocr_result_hash
+
+        # Normal publish: rewrite the artifact AND publish the new hash.
+        (ocr_dir / "structure" / "blocks.structured.jsonl").write_text(
+            json.dumps({"blocks": ["KEY1", "new"]}), encoding="utf-8"
+        )
+        publish_ocr_result_hash(ocr_dir)
+        payload = probe_lineage(vault)
+        assert payload["papers"]["KEY1"] == {
+            "ocr": "current", "retrieval": "stale", "vector": "stale",
+        }
+
+    def test_new_retrieval_publish_marks_old_vector_stale(self, tmp_path: Path) -> None:
+        """#162 P0-2: after memory publishes a new retrieval identity, old
+        vectors (derived_from the previous identity) are stale even though
+        the retrieval layer itself is current."""
+        vault = _make_vault(tmp_path)
+        indexes = vault / "99_System" / "PaperForge" / "indexes"
+        conn = sqlite3.connect(str(indexes / "paperforge.db"))
+        try:
+            manifest = json.loads(
+                conn.execute("SELECT value FROM meta WHERE key='manifest:KEY1'").fetchone()[0]
+            )
+            # Simulate a memory publish: unit digests changed → new identity,
+            # stored consistently in the manifest (retrieval stays current).
+            manifest["body_units_hash"] = "f" * 64
+            manifest["retrieval_identity"] = compute_retrieval_identity(
+                ocr_result_hash=manifest["ocr_result_hash"],
+                retrieval_policy_version=manifest["retrieval_policy_version"],
+                structure_tree_hash=manifest["structure_tree_hash"],
+                body_units_hash=manifest["body_units_hash"],
+                object_units_hash=manifest["object_units_hash"],
+            )
+            conn.execute(
+                "INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)",
+                ("manifest:KEY1", json.dumps(manifest)),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        payload = probe_lineage(vault)
+        assert payload["papers"]["KEY1"]["ocr"] == "current"
+        assert payload["papers"]["KEY1"]["retrieval"] == "current"
+        # Vector lineage still derives from the OLD retrieval identity.
+        assert payload["papers"]["KEY1"]["vector"] == "stale"
+
+    def test_policy_bump_marks_retrieval_and_vector_stale(self, tmp_path: Path, monkeypatch) -> None:
+        """#162 P0-1: a retrieval-policy bump (global desired state) makes
+        manifests built under the old policy stale."""
+        vault = _make_vault(tmp_path)
+        import paperforge.retrieval.manifest as manifest_mod
+
+        monkeypatch.setattr(manifest_mod, "RETRIEVAL_POLICY_VERSION", "l4.body.v999")
+        payload = probe_lineage(vault)
+        assert payload["papers"]["KEY1"]["ocr"] == "current"
+        assert payload["papers"]["KEY1"]["retrieval"] == "stale"
+        assert payload["papers"]["KEY1"]["vector"] == "stale"
+
     def test_cli_output_shape_and_no_autorebuild(self, tmp_path: Path) -> None:
         vault = _make_vault(tmp_path)
         result = subprocess.run(


### PR DESCRIPTION
## T1 corrective closure (review of #177)

Two P0 observation gaps on the #159 state transitions, plus the P1 collector-digest mechanism gap. Small, focused PR.

### P0-1 — normal OCR publish now marks retrieval stale
`_probe_retrieval_state` recomputed the manifest's identity from the manifest's OWN recorded (old) fields, so a normal publish (artifacts + result-hash both updated) left retrieval self-consistent → current. Fix: compare `manifest.ocr_result_hash` against the **current published OCR identity**, and `manifest.retrieval_policy_version` against the current policy constant (global desired state, #159 §2.1).

### P0-2 — new retrieval publish now marks old vectors stale
`_probe_vector_state` verified `stored_identity == hash(derived_from + E)` but never verified `derived_from == current retrieval identity`. Fix: verify `derived_from` against the current identity before the stored-vs-recomputed comparison.

Probe chain now threads `(state, identity)` layer by layer (OCR → retrieval → vector). Three regression tests:

| Test | Scenario | Expectation |
|---|---|---|
| `test_new_published_ocr_identity_marks_retrieval_and_vector_stale` | OCR=A/R1/V1 → normal publish OCR=B | ocr current, retrieval stale, vector stale |
| `test_new_retrieval_publish_marks_old_vector_stale` | OCR=A/R1/V1(derived R1) → memory publishes R2 | ocr current, retrieval current, vector stale |
| `test_policy_bump_marks_retrieval_and_vector_stale` | policy vN → vN+1 | retrieval stale, vector stale |

### P1 — collector digests canonicalized like the verifier
`canonical_source_bytes` (Python) + `replace(/\r\n/g, "\n")` (TS) now normalize before hashing; the golden verifier already did. Windows vs CI surveys are identical.

### Evidence
- Python full suite **2958 passed / 296 skipped**; ruff clean; audit suites (collectors/fixtures/reconcile) 117 passed
- CI: J-Matrix 3-OS + full matrix

Closes: #162.