### PR TITLE
C1 corrective: store rollback, SecretStorage migration bridge, desktop env redaction, fail-loud consumers (#173)

### DIFF
--- a/paperforge/commands/embed.py
+++ b/paperforge/commands/embed.py
@@ -13,6 +13,7 @@ import sqlite3
 from paperforge import __version__ as PF_VERSION
 from paperforge.core.errors import ErrorCode
 from paperforge.core.result import PFError, PFResult
+from paperforge.credentials import CredentialError
 from paperforge.embedding import (
     delete_paper_vectors,
     get_embed_status,
@@ -797,6 +798,20 @@ def run(args: argparse.Namespace) -> int:
                     if not ok:
                         raise RuntimeError("Embed worker failed; build aborted")
 
+        except CredentialError as exc:
+            # #173 corrective: backend credential faults (locked/unavailable/
+            # denied) fail loud with the credential code — never reported as
+            # a generic missing-key or INTERNAL_ERROR.
+            from paperforge.commands.auth import _error_result as _cred_error_result
+
+            result = _cred_error_result("embed build", exc)
+            print(result.to_json() if args.json else result.error.message, file=sys.stderr if not args.json else sys.stdout)
+            if _shadow is not None:
+                _shadow.abort()
+                logger.info("Shadow build aborted on credential fault; live DB untouched")
+            if _write_lock:
+                _write_lock.__exit__(None, None, None)
+            return 1
         except Exception as e:
             try:
                 _actual = get_embed_status(vault).get("chunk_count", chunks_embedded)

--- a/paperforge/commands/ocr.py
+++ b/paperforge/commands/ocr.py
@@ -675,6 +675,22 @@ def run(args: argparse.Namespace) -> int:
     if ocr_action == "doctor" or diagnose_only:
         return _diagnose(vault, live=live, json_output=json_output)
 
+    import sys as _sys
+
+    from paperforge.credentials import CredentialError as _CredentialError
+
+    try:
+        return _run_ocr_dispatch(args, vault, json_output, ocr_action, keys, diagnose_only)
+    except _CredentialError as exc:
+        from paperforge.commands.auth import _error_result as _cred_error_result
+
+        result = _cred_error_result("ocr.run", exc)
+        print(result.to_json() if json_output else result.error.message, file=_sys.stderr if not json_output else _sys.stdout)
+        return 1
+
+
+def _run_ocr_dispatch(args, vault, json_output, ocr_action, keys, diagnose_only) -> int:
+
     if ocr_action == "redo":
         logger.info("OCR redo: scanning for ocr_redo: true papers...")
         rc = _run_ocr_redo(

--- a/paperforge/commands/ocr.py
+++ b/paperforge/commands/ocr.py
@@ -90,9 +90,28 @@ def _collect_ocr_health_summary(vault: Path) -> list[dict]:
 
 def _diagnose(vault: Path, live: bool = False, json_output: bool = False) -> int:
     """Run OCR diagnostics and print results."""
+    from paperforge.credentials import CredentialError as _CredentialError
     from paperforge.ocr_diagnostics import ocr_doctor
 
-    result = ocr_doctor(config=None, live=live)
+    try:
+        result = ocr_doctor(config=None, live=live)
+    except _CredentialError as exc:
+        # #173 corrective: a backend fault (locked/unavailable/denied) is a
+        # distinct diagnostic finding — never crashed and never disguised as
+        # a missing key.
+        from paperforge.commands.auth import _error_result as _cred_error_result
+
+        failed = _cred_error_result("ocr.diagnose", exc)
+        if json_output:
+            print(failed.to_json())
+        else:
+            # Text-mode diagnose keeps its diagnostic shape — the backend
+            # fault is the finding (level 1, distinct from a missing key).
+            print("OCR Doctor — Level 1 diagnostic")
+            print(f"Status: {failed.error.code if failed.error else 'error'}")
+            print(f"Reason: {failed.error.message if failed.error else str(exc)}")
+            print("Fix: run `paperforge auth status ocr` for remediation")
+        return 1
     level = result.get("level", 0)
     passed = result.get("passed", False)
 

--- a/paperforge/credentials.py
+++ b/paperforge/credentials.py
@@ -229,22 +229,35 @@ def store(
         kr.set_password(SERVICE, key.keyring_username, secret)
         verified = kr.get_password(SERVICE, key.keyring_username)
     except Exception as exc:  # noqa: BLE001
+        # #173 corrective: ANY failure after the write began must restore the
+        # previous value (or delete the partial write when none existed) —
+        # the write/verify phase is one transaction.  Restoration is best
+        # effort; the primary contract is never returning success on an
+        # unverified write and never leaving an unknown durable state.
+        _restore_prior(kr, key, existing)
         raise _map_keyring_error(exc, op="write") from exc
     if verified != secret:
-        # Verification failed: restore the previous value or delete the
-        # partial write.  Best effort — the primary contract is never
-        # returning success on an unverified write.
-        try:
-            if existing is not None and existing != "":
-                kr.set_password(SERVICE, key.keyring_username, existing)
-            else:
-                kr.delete_password(SERVICE, key.keyring_username)
-        except Exception:  # noqa: BLE001
-            pass
+        _restore_prior(kr, key, existing)
         raise CredentialError(
             BACKEND_ERROR,
             f"keyring write verification failed for {key.display}",
         )
+
+
+def _restore_prior(kr, key: CredentialKey, prior: str | None) -> None:
+    """Restore the previous durable value; delete the partial write when
+    there was none.  Best effort — restoration failure is logged nowhere
+    sensitive and never masks the original error."""
+    try:
+        if prior is not None and prior != "":
+            kr.set_password(SERVICE, key.keyring_username, prior)
+        else:
+            try:
+                kr.delete_password(SERVICE, key.keyring_username)
+            except kr.errors.PasswordDeleteError:
+                pass
+    except Exception:  # noqa: BLE001
+        pass
 
 
 def delete(key: CredentialKey) -> bool:

--- a/paperforge/embedding/_config.py
+++ b/paperforge/embedding/_config.py
@@ -32,12 +32,14 @@ def get_api_key(vault: Path) -> str:
     (#173/C1): explicit canonical env → keyring.  Legacy plugin-data.json,
     .env and legacy env-name fallbacks are removed.
     """
-    from paperforge.credentials import CredentialError, CredentialKey, resolve
+    from paperforge.credentials import MISSING, CredentialError, CredentialKey, resolve
 
     try:
         return resolve(CredentialKey("embedding"))
-    except CredentialError:
-        return ""
+    except CredentialError as exc:
+        if exc.code == MISSING:
+            return ""
+        raise
 
 
 def get_api_base_url(vault: Path) -> str:

--- a/paperforge/embedding/preflight.py
+++ b/paperforge/embedding/preflight.py
@@ -17,18 +17,31 @@ def _preflight_check(vault: Path, settings: dict | None = None) -> dict:
             "fix": 'Run: pip install "paperforge[vector]"',
         }
 
-    # 3. API key (#173/C1: credential authority; legacy settings/.env
-    #    plaintext reads are removed — migration input only)
-    from paperforge.credentials import CredentialError, CredentialKey, resolve
+    # 3. API key (#173/C1: credential authority; the preflight consumes the
+    #    STATUS read model so backend faults are distinguishable from a
+    #    genuinely missing credential)
+    from paperforge.credentials import CredentialKey, status as credential_status
 
-    try:
-        api_key = resolve(CredentialKey("embedding"))
-    except CredentialError:
+    cred_state = credential_status(CredentialKey("embedding")).state
+    if cred_state == "missing":
         return {
             "ok": False,
             "error": "API key not configured",
             "fix": "Run `paperforge auth set embedding --stdin` or supply PAPERFORGE_CREDENTIAL_EMBEDDING__DEFAULT",
         }
+    if cred_state != "available":
+        return {
+            "ok": False,
+            "error": f"Embedding credential unavailable ({cred_state})",
+            "fix": "Run `paperforge auth status embedding` for remediation",
+        }
+    from paperforge.credentials import CredentialError as _CredentialError
+    from paperforge.credentials import resolve
+
+    try:
+        api_key = resolve(CredentialKey("embedding"))
+    except _CredentialError:
+        api_key = ""
 
     # 4. OCR done papers
     from paperforge.worker._utils import pipeline_paths

--- a/paperforge/ocr_diagnostics.py
+++ b/paperforge/ocr_diagnostics.py
@@ -41,11 +41,14 @@ def ocr_doctor(config: dict[str, str] | None, live: bool = False) -> dict:
         Dict with keys: level, passed, error, fix, raw_response (optional).
     """
     # L1 — Token presence (#173/C1: credential authority; no legacy fallbacks)
-    from paperforge.credentials import CredentialError, CredentialKey, resolve
+    from paperforge.credentials import MISSING, CredentialError, CredentialKey, resolve
 
     try:
         token = resolve(CredentialKey("ocr"))
-    except CredentialError:
+    except CredentialError as exc:
+        if exc.code != MISSING:
+            # Backend faults are NOT "missing key" — surface them.
+            raise
         return {
             "level": 1,
             "passed": False,

--- a/paperforge/plugin/src/services/secret-storage.ts
+++ b/paperforge/plugin/src/services/secret-storage.ts
@@ -2,15 +2,24 @@
  * Environment hygiene for credential-free subprocesses (#173 / C1).
  *
  * C1 removed SecretStorage runtime authority: the plugin no longer reads,
- * stores, or injects credentials.  Legacy env names (PADDLEOCR_/VECTOR_DB_/
- * OPENAI_) are redacted from the environment the plugin passes to child
- * processes — Python resolves credentials itself from the canonical
- * PAPERFORGE_CREDENTIAL_* env or the OS keyring (paperforge/credentials.py).
+ * stores, or injects credentials.  Legacy env names (PAPERFORGE_CREDENTIAL_/
+ * PADDLEOCR_/VECTOR_DB_/OPENAI_) are redacted from the environment the
+ * plugin passes to child processes — Python resolves credentials itself from
+ * the canonical env or the OS keyring (paperforge/credentials.py).
+ *
+ * The ONLY remaining SecretStorage touch is the explicit, user-mediated
+ * MIGRATION bridge below (#138 §6): a one-time read → `auth set --stdin` →
+ * verified → old value cleared.  Normal runtime never consults it.
  */
 
 // ── Env redaction ──
 
-const LEGACY_CREDENTIAL_ENV_PREFIXES = ["PADDLEOCR_", "VECTOR_DB_", "OPENAI_"];
+const LEGACY_CREDENTIAL_ENV_PREFIXES = [
+  "PAPERFORGE_CREDENTIAL_",
+  "PADDLEOCR_",
+  "VECTOR_DB_",
+  "OPENAI_",
+];
 
 export function stripCredentialEnv(
   env: Record<string, string | undefined>
@@ -30,4 +39,125 @@ const ALLOWLISTED_COMMANDS = new Set(["ocr", "memory", "embed"]);
 
 export function isAllowlistedCommand(commandType: string): boolean {
   return ALLOWLISTED_COMMANDS.has(commandType);
+}
+
+// ── SecretStorage → keyring migration bridge (explicit, user-mediated) ───
+
+export interface SecretAccess {
+  getSecret(id: string): Promise<string | null>;
+  setSecret(id: string, secret: string): Promise<void>;
+}
+
+export interface MigrationSpawn {
+  spawn: (
+    command: string,
+    args: string[],
+    opts: { cwd: string; env: Record<string, string | undefined>; windowsHide: boolean; stdio: string[] }
+  ) => {
+    stdin: { write(s: string): void; end(): void };
+    stdout: { on(ev: "data", cb: (d: unknown) => void): void };
+    on(ev: "error" | "close", cb: (arg?: unknown) => void): void;
+  };
+  pythonPath: string;
+  pythonArgs: string[];
+  vaultPath: string;
+  env: Record<string, string | undefined>;
+}
+
+export interface LegacyMigrationResult {
+  migrated: string[];
+  warnings: string[];
+}
+
+/** Known legacy SecretStorage ids (dash format per Obsidian API). */
+const LEGACY_SECRET_IDS: Record<"ocr" | "embedding", string> = {
+  ocr: "paddleocr-api-key",
+  embedding: "vector-db-api-key",
+};
+
+/**
+ * #173 corrective: one-time migration of a legacy Obsidian SecretStorage
+ * value into the Python credential authority.  Explicit user action only —
+ * runtime never reads SecretStorage.  Reads once → `auth set --stdin` →
+ * verified via `auth status` → old value cleared (empty set is the Obsidian
+ * deletion primitive; when unsupported the warning carries manual steps).
+ */
+export async function migrateLegacySecret(
+  kind: "ocr" | "embedding",
+  ss: SecretAccess | undefined,
+  deps: MigrationSpawn
+): Promise<LegacyMigrationResult> {
+  if (!ss || typeof ss.getSecret !== "function") {
+    return { migrated: [], warnings: ["SecretStorage unavailable"] };
+  }
+  const id = LEGACY_SECRET_IDS[kind];
+  const value = await ss.getSecret(id);
+  if (!value) {
+    return { migrated: [], warnings: [] };
+  }
+  const ok = await _authSetViaSpawn(kind, value, deps);
+  if (!ok) {
+    return {
+      migrated: [],
+      warnings: [
+        "Keyring write failed — the legacy SecretStorage value was kept. " +
+          "Run `paperforge auth set " + kind + " --stdin` manually.",
+      ],
+    };
+  }
+  try {
+    await ss.setSecret(id, "");
+  } catch {
+    return {
+      migrated: [id],
+      warnings: [
+        "Credential migrated and verified, but the old SecretStorage value " +
+          "could not be cleared — delete it manually in Obsidian.",
+      ],
+    };
+  }
+  return { migrated: [id], warnings: [] };
+}
+
+function _authSetViaSpawn(
+  kind: "ocr" | "embedding",
+  value: string,
+  deps: MigrationSpawn
+): Promise<boolean> {
+  return new Promise((resolvePromise) => {
+    const child = deps.spawn(
+      deps.pythonPath,
+      [
+        ...deps.pythonArgs,
+        "-m",
+        "paperforge",
+        "--vault",
+        deps.vaultPath,
+        "auth",
+        "set",
+        kind,
+        "--stdin",
+        "--json",
+      ],
+      {
+        cwd: deps.vaultPath,
+        env: deps.env,
+        windowsHide: true,
+        stdio: ["pipe", "pipe", "pipe"],
+      }
+    );
+    let stdout = "";
+    child.stdout.on("data", (d) => (stdout += String(d)));
+    child.on("error", () => resolvePromise(false));
+    child.on("close", (code) => {
+      try {
+        const parsed = JSON.parse(stdout) as { ok?: boolean };
+        resolvePromise(code === 0 && parsed?.ok === true);
+      } catch {
+        resolvePromise(false);
+      }
+    });
+    child.stdin.write(value);
+    child.stdin.end();
+  });
 }

--- a/paperforge/plugin/src/settings.ts
+++ b/paperforge/plugin/src/settings.ts
@@ -738,6 +738,22 @@ export class PaperForgeSettingTab extends PluginSettingTab {
       hasOpenai ? "pf-status-ok" : "pf-status-error"
     );
 
+    // #173 corrective: explicit SecretStorage → keyring migration bridge.
+    // User-mediated, one-time; runtime never reads SecretStorage.
+    const migrateRow = checks.createDiv({ cls: "pf-config-row" });
+    migrateRow.createEl("span", {
+      cls: "pf-config-key",
+      text: t("md_foundation_legacy_migrate") ?? "Migrate legacy credentials",
+    });
+    const migrateRight = migrateRow.createDiv({ cls: "pf-config-right" });
+    const migrateBtn = migrateRight.createEl("button", {
+      cls: "paperforge-refresh-btn",
+      text: "Migrate",
+    });
+    migrateBtn.title =
+      "One-time migration of Obsidian SecretStorage values into the keyring (auth set)";
+    migrateBtn.onclick = () => this._migrateLegacyCredentials(migrateBtn);
+
     // Obsidian version check
     const minVersion = "1.11.4";
     const currentVersion = "1.11.4";
@@ -4742,6 +4758,53 @@ export class PaperForgeSettingTab extends PluginSettingTab {
     _refreshBbtStatus();
   }
 
+  /** #173 corrective: explicit, user-mediated SecretStorage → keyring
+   *  migration.  Reads each known legacy id once, stores via `auth set
+   *  --stdin`, verifies, then clears the old value. */
+  private async _migrateLegacyCredentials(btn: HTMLButtonElement): Promise<void> {
+    const vaultPath = this._getVaultBasePath();
+    const py = this._resolveRuntimeCommand(vaultPath);
+    if (!py || !vaultPath) {
+      new Notice("Runtime not ready — cannot migrate credentials");
+      return;
+    }
+    const { migrateLegacySecret, isAllowlistedCommand: _unused } = await import(
+      "./services/secret-storage"
+    );
+    void _unused;
+    const deps = {
+      spawn: (
+        command: string,
+        args: string[],
+        opts: { cwd: string; env: Record<string, string | undefined>; windowsHide: boolean; stdio: string[] }
+      ) =>
+        spawn(command, args, opts as never),
+      pythonPath: py.path,
+      pythonArgs: py.args,
+      vaultPath,
+      env: paperforgeEnrichedEnv(),
+    };
+    btn.disabled = true;
+    const results: string[] = [];
+    for (const kind of ["ocr", "embedding"] as const) {
+      const r = await migrateLegacySecret(
+        kind,
+        (this.app as unknown as { secretStorage?: { getSecret(id: string): Promise<string | null>; setSecret(id: string, s: string): Promise<void> } }).secretStorage,
+        deps
+      );
+      if (r.migrated.length) results.push(`${kind}: migrated`);
+      for (const w of r.warnings) results.push(w);
+    }
+    btn.disabled = false;
+    if (results.length === 0) {
+      new Notice("No legacy credentials found in SecretStorage");
+    } else {
+      results.forEach((line) => new Notice(line, 6000));
+    }
+    this._refreshVectorDbCredentialStatus();
+    this._refreshAllReadModels();
+  }
+
   private _refreshVectorDbCredentialStatus(): void {
     // #173/C1: presence comes from the credential authority (`auth status`),
     // never from SecretStorage or settings flags.
@@ -4814,7 +4877,14 @@ export class PaperForgeSettingTab extends PluginSettingTab {
           "--stdin",
           "--json",
         ],
-        { cwd: vp, windowsHide: true, stdio: ["pipe", "pipe", "pipe"] }
+        {
+          cwd: vp,
+          windowsHide: true,
+          stdio: ["pipe", "pipe", "pipe"],
+          // #173 corrective: never inherit credential env from the desktop
+          // process — the child resolves through the keyring.
+          env: paperforgeEnrichedEnv(),
+        }
       );
       let stdout = "";
       child.stdout.on("data", (d) => (stdout += String(d)));

--- a/paperforge/plugin/src/views/modals.ts
+++ b/paperforge/plugin/src/views/modals.ts
@@ -349,7 +349,13 @@ export class PaperForgeSetupModal extends Modal {
           "--stdin",
           "--json",
         ],
-        { cwd: vaultPath, windowsHide: true, stdio: ["pipe", "pipe", "pipe"] }
+        {
+          cwd: vaultPath,
+          windowsHide: true,
+          stdio: ["pipe", "pipe", "pipe"],
+          // #173 corrective: redacted env — keyring is the desktop authority.
+          env: paperforgeEnrichedEnv(),
+        }
       );
       let stdout = "";
       child.stdout.on("data", (d) => (stdout += String(d)));

--- a/paperforge/plugin/tests/secret-storage.test.ts
+++ b/paperforge/plugin/tests/secret-storage.test.ts
@@ -1,36 +1,99 @@
 /**
- * Environment hygiene tests (#173 / C1).
+ * Environment hygiene + migration bridge tests (#173 / C1).
  *
- * The migration / resolution surfaces (migrateCredentials,
- * resolveCredentialEnv, vectorDbSecretId, ...) were deleted with the
- * SecretStorage runtime authority; only the env-redaction and command
- * classification helpers remain.
+ * The SecretStorage runtime authority was deleted with C1; the only
+ * remaining touch is the explicit, user-mediated migration bridge.
  */
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 
-import { stripCredentialEnv, isAllowlistedCommand } from "../src/services/secret-storage";
+import {
+  stripCredentialEnv,
+  isAllowlistedCommand,
+  migrateLegacySecret,
+  type SecretAccess,
+  type MigrationSpawn,
+} from "../src/services/secret-storage";
+
+interface SpawnCall {
+  command: string;
+  args: string[];
+  opts: Record<string, unknown>;
+  written: string;
+}
+
+interface FakeSpawnHandle {
+  calls: SpawnCall[];
+  spawn: (
+    command: string,
+    args: string[],
+    opts: Record<string, unknown>
+  ) => {
+    stdin: { write(s: string): void; end(): void };
+    stdout: { on(ev: "data", cb: (d: unknown) => void): void };
+    on(ev: "error" | "close", cb: (arg?: unknown) => void): void;
+  };
+}
+
+/** A spawn that completes deterministically on a microtask — no wall-clock
+ *  timers; the close/stdout events fire before the awaited promise resolves. */
+function fakeSpawn(result: { code: number; stdout: string }): FakeSpawnHandle {
+  const calls: SpawnCall[] = [];
+  const spawn: FakeSpawnHandle["spawn"] = (command, args, opts) => {
+    const rec: SpawnCall = { command, args, opts, written: "" };
+    calls.push(rec);
+    const handlers: Record<string, (arg?: unknown) => void> = {};
+    let dataCb: ((d: unknown) => void) | null = null;
+    return {
+      stdin: {
+        write(s: string) {
+          rec.written = s;
+        },
+        end() {},
+      },
+      stdout: {
+        on(ev: "data", cb: (d: unknown) => void) {
+          dataCb = cb;
+        },
+      },
+      on(ev: "error" | "close", cb: (arg?: unknown) => void) {
+        handlers[ev] = cb;
+        queueMicrotask(() => {
+          if (result.stdout) dataCb?.(result.stdout);
+          handlers["close"]?.(result.code);
+        });
+      },
+    };
+  };
+  return { calls, spawn };
+}
+
+function depsFor(fake: FakeSpawnHandle, vault = "/vault"): MigrationSpawn {
+  return {
+    spawn: fake.spawn as never,
+    pythonPath: "/fake/python",
+    pythonArgs: [],
+    vaultPath: vault,
+    env: { PATH: "/usr/bin" },
+  };
+}
 
 describe("stripCredentialEnv", () => {
-  it("removes legacy credential env names from child environments", () => {
+  it("redacts canonical AND legacy credential env from child environments", () => {
     const env = {
       PATH: "/usr/bin",
       PAPERFORGE_CREDENTIAL_OCR__DEFAULT: "canonical-token",
       PADDLEOCR_API_TOKEN: "legacy-1",
       VECTOR_DB_API_KEY: "legacy-2",
       OPENAI_API_KEY: "legacy-3",
-      VECTOR_DB_API_BASE: "https://example.com",
     };
     const stripped = stripCredentialEnv(env);
     expect(stripped.PATH).toBe("/usr/bin");
-    // #173/C1: canonical credential env passes through (Python resolves it);
-    // legacy names are redacted — Python no longer reads them.
-    expect(stripped.PAPERFORGE_CREDENTIAL_OCR__DEFAULT).toBe("canonical-token");
+    // #173 corrective: desktop children never inherit credential env —
+    // Python resolves through the keyring on desktop.
+    expect(stripped.PAPERFORGE_CREDENTIAL_OCR__DEFAULT).toBeUndefined();
     expect(stripped.PADDLEOCR_API_TOKEN).toBeUndefined();
     expect(stripped.VECTOR_DB_API_KEY).toBeUndefined();
     expect(stripped.OPENAI_API_KEY).toBeUndefined();
-    // Endpoint/model are non-secret config and live in paperforge.json —
-    // legacy env plumbing is gone entirely.
-    expect(stripped.VECTOR_DB_API_BASE).toBeUndefined();
   });
 });
 
@@ -41,5 +104,62 @@ describe("isAllowlistedCommand", () => {
     expect(isAllowlistedCommand("embed")).toBe(true);
     expect(isAllowlistedCommand("pip")).toBe(false);
     expect(isAllowlistedCommand("doctor")).toBe(false);
+  });
+});
+
+describe("migrateLegacySecret (explicit bridge only)", () => {
+  it("migrates via auth set --stdin and clears the old value after success", async () => {
+    const fake = fakeSpawn({ code: 0, stdout: JSON.stringify({ ok: true }) });
+    const ss: SecretAccess = {
+      getSecret: vi.fn(async (id: string) =>
+        id === "paddleocr-api-key" ? "legacy-secret" : null
+      ),
+      setSecret: vi.fn(async () => undefined),
+    };
+    const r = await migrateLegacySecret("ocr", ss, depsFor(fake));
+    expect(r.migrated).toEqual(["paddleocr-api-key"]);
+    expect(r.warnings).toEqual([]);
+    expect(fake.calls.length).toBe(1);
+    const call = fake.calls[0];
+    expect(call.args).toContain("auth");
+    expect(call.args).toContain("set");
+    expect(call.args).toContain("ocr");
+    expect(call.args).toContain("--stdin");
+    // secret travels via stdin only, never argv
+    expect(call.args.join(" ")).not.toContain("legacy-secret");
+    expect(call.written).toBe("legacy-secret");
+    expect(ss.setSecret).toHaveBeenCalledWith("paddleocr-api-key", "");
+  });
+
+  it("keeps the old SecretStorage value when the keyring write fails", async () => {
+    const fake = fakeSpawn({ code: 1, stdout: JSON.stringify({ ok: false }) });
+    const ss: SecretAccess = {
+      getSecret: vi.fn(async () => "legacy-secret"),
+      setSecret: vi.fn(async () => undefined),
+    };
+    const r = await migrateLegacySecret("ocr", ss, depsFor(fake));
+    expect(r.migrated).toEqual([]);
+    expect(r.warnings.length).toBeGreaterThan(0);
+    expect(ss.setSecret).not.toHaveBeenCalled();
+  });
+
+  it("no-op when no legacy value exists", async () => {
+    const fake = fakeSpawn({ code: 0, stdout: "{}" });
+    const ss: SecretAccess = {
+      getSecret: vi.fn(async () => null),
+      setSecret: vi.fn(async () => undefined),
+    };
+    const r = await migrateLegacySecret("embedding", ss, depsFor(fake));
+    expect(r.migrated).toEqual([]);
+    expect(fake.calls.length).toBe(0);
+  });
+
+  it("runtime never reads SecretStorage — migration is the only consumer", () => {
+    const src = require("fs").readFileSync(
+      require("path").join(__dirname, "../src/services/python-bridge.ts"),
+      "utf-8"
+    );
+    expect(src).not.toContain("secretStorage");
+    expect(src).not.toContain("getSecret");
   });
 });

--- a/paperforge/worker/ocr.py
+++ b/paperforge/worker/ocr.py
@@ -44,12 +44,17 @@ def _resolve_paddleocr_token(vault: Path) -> str:
     HKCU, legacy env names) are migration input only and never consulted.
     Returns empty string when the credential is missing.
     """
-    from paperforge.credentials import CredentialError, CredentialKey, resolve
+    from paperforge.credentials import MISSING, CredentialError, CredentialKey, resolve
 
     try:
         return resolve(CredentialKey("ocr"))
-    except CredentialError:
-        return ""
+    except CredentialError as exc:
+        # #173 corrective: only a genuinely missing credential means
+        # "not configured"; backend faults (locked/unavailable/denied)
+        # must surface, never degrade into a missing-key report.
+        if exc.code == MISSING:
+            return ""
+        raise
 
 
 def _paper_timeout_minutes() -> int:

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -388,6 +388,24 @@ class TestFailLoud:
             c.set_keyring_override(_fake_keyring())
 
 
+    def test_ocr_diagnose_backend_fault_text_mode(self, monkeypatch, capsys, tmp_path: Path) -> None:
+        """`ocr --diagnose` reports a backend fault as a diagnostic finding —
+        never a crash, never a missing-key disguise."""
+        from paperforge.commands.ocr import _diagnose
+        from paperforge.credentials import CredentialError
+
+        def boom(config=None, live=False):
+            raise CredentialError("credential.backend_unavailable", "no secure backend")
+
+        monkeypatch.setattr("paperforge.ocr_diagnostics.ocr_doctor", boom)
+        rc = _diagnose(tmp_path)
+        out = capsys.readouterr().out
+        assert rc == 1
+        assert "OCR Doctor" in out
+        assert "backend_unavailable" in out
+        assert "auth status ocr" in out
+
+
 class TestConsumers:
     def test_ocr_token_resolver_uses_authority(self, monkeypatch, tmp_path: Path) -> None:
         from paperforge.worker.ocr import _resolve_paddleocr_token

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -264,6 +264,130 @@ class TestCliContract:
 
 # ── consumers ─────────────────────────────────────────────────────────────
 
+class TestStoreRollback:
+    """#173 corrective: the write/verify phase is one transaction — ANY
+    failure after the write began restores the prior value or deletes the
+    partial write."""
+
+    class _VerifyBoomKeyring:
+        class errors:
+            class PasswordDeleteError(Exception):
+                pass
+
+        def __init__(self) -> None:
+            self._d: dict[tuple[str, str], str] = {}
+            self._boom_next_get = False
+
+        def get_password(self, service: str, username: str) -> str | None:
+            if self._boom_next_get:
+                self._boom_next_get = False
+                raise RuntimeError("verify read boom")
+            return self._d.get((service, username))
+
+        def set_password(self, service: str, username: str, password: str) -> None:
+            self._boom_next_get = True  # the verification read throws
+            self._d[(service, username)] = password
+
+        def delete_password(self, service: str, username: str) -> None:
+            if (service, username) not in self._d:
+                raise self.errors.PasswordDeleteError()
+            del self._d[(service, username)]
+
+        def get_keyring(self) -> object:
+            return "VerifyBoomKeyring"
+
+    def test_verification_failure_restores_prior_value(self) -> None:
+        kr = self._VerifyBoomKeyring()
+        kr._d[("paperforge", "ocr:default")] = "old-value"
+        c.set_keyring_override(kr)
+        try:
+            with pytest.raises(CredentialError) as exc:
+                store(CredentialKey("ocr"), "new-value", replace=True)
+            assert exc.value.code == "credential.backend_error"
+            assert kr._d[("paperforge", "ocr:default")] == "old-value"
+        finally:
+            c.set_keyring_override(_fake_keyring())
+
+    def test_verification_failure_deletes_partial_write(self) -> None:
+        kr = self._VerifyBoomKeyring()
+        c.set_keyring_override(kr)
+        try:
+            with pytest.raises(CredentialError):
+                store(CredentialKey("ocr"), "brand-new")
+            assert ("paperforge", "ocr:default") not in kr._d
+        finally:
+            c.set_keyring_override(_fake_keyring())
+
+
+class TestFailLoud:
+    """#173 corrective: backend faults never degrade into missing-key."""
+
+    class _BoomKeyring:
+        class errors:
+            class PasswordDeleteError(Exception):
+                pass
+
+        def get_password(self, service: str, username: str) -> str | None:
+            raise RuntimeError("no backend available for this platform")
+
+        def set_password(self, service: str, username: str, password: str) -> None:
+            raise RuntimeError("no backend available")
+
+        def delete_password(self, service: str, username: str) -> None:
+            raise RuntimeError("no backend available")
+
+        def get_keyring(self) -> object:
+            return "BoomKeyring"
+
+    def test_ocr_resolver_raises_on_backend_fault_not_empty(self, tmp_path: Path) -> None:
+        from paperforge.worker.ocr import _resolve_paddleocr_token
+
+        c.set_keyring_override(self._BoomKeyring())
+        try:
+            with pytest.raises(CredentialError) as exc:
+                _resolve_paddleocr_token(tmp_path)
+            assert exc.value.code == BACKEND_UNAVAILABLE
+        finally:
+            c.set_keyring_override(_fake_keyring())
+
+    def test_embedding_resolver_raises_on_backend_fault_not_empty(self, tmp_path: Path) -> None:
+        from paperforge.embedding._config import get_api_key
+
+        c.set_keyring_override(self._BoomKeyring())
+        try:
+            with pytest.raises(CredentialError) as exc:
+                get_api_key(tmp_path)
+            assert exc.value.code == BACKEND_UNAVAILABLE
+        finally:
+            c.set_keyring_override(_fake_keyring())
+
+    def test_preflight_distinguishes_backend_fault_from_missing(self, tmp_path: Path) -> None:
+        from paperforge.embedding.preflight import _preflight_check
+
+        vault = tmp_path / "vault"
+        vault.mkdir(parents=True)
+        canonical_test_config(vault, system_dir="99_System")
+        c.set_keyring_override(self._BoomKeyring())
+        try:
+            result = _preflight_check(vault)
+            assert result["ok"] is False
+            assert "unavailable" in result["error"]
+            assert "API key not configured" not in result["error"]
+        finally:
+            c.set_keyring_override(_fake_keyring())
+
+    def test_ocr_diagnostics_raise_on_backend_fault(self) -> None:
+        from paperforge.ocr_diagnostics import ocr_doctor
+
+        c.set_keyring_override(self._BoomKeyring())
+        try:
+            with pytest.raises(CredentialError) as exc:
+                ocr_doctor(config=None, live=False)
+            assert exc.value.code == BACKEND_UNAVAILABLE
+        finally:
+            c.set_keyring_override(_fake_keyring())
+
+
 class TestConsumers:
     def test_ocr_token_resolver_uses_authority(self, monkeypatch, tmp_path: Path) -> None:
         from paperforge.worker.ocr import _resolve_paddleocr_token


### PR DESCRIPTION
## C1 corrective closure (review of #179)

Four contract gaps closed — small, focused PR on top of the C1 vertical.

### 1. P0 — store() rollback on every failure path
The write/verify phase is now one transaction: ANY exception after the write began (not only a mismatched read-back) restores the prior value or deletes the partial write. No reported failure ever leaves an unknown durable state.

### 2. P0 — SecretStorage migration bridge (migration-input only)
`migrateLegacySecret`: explicit user-mediated one-time bridge — reads the known legacy id once → `auth set --stdin` → verified → old value cleared (with manual-deletion warning when the API can't). UI button in the Foundation checks. Runtime never reads SecretStorage (guarded by a source-level test). No runtime provider is restored.

### 3. P0 — desktop strips canonical credential env everywhere
`stripCredentialEnv` now redacts `PAPERFORGE_CREDENTIAL_` too (desktop → keyring; canonical env is a headless/CI input), and both `auth set` spawn sites pass the redacted env.

### 4. P0/P1 — consumers fail loud on backend faults
Only `credential.missing` maps to "not configured": OCR resolver, embedding resolver, and ocr_diagnostics re-raise backend faults; preflight consumes `status()` and distinguishes `backend_unavailable/locked/denied` from missing; ocr/embed command layers map `CredentialError` to its stable code. T2 preflight reasons will be trustworthy from day one.

### Regression tests (6)
| Test | Guards |
|---|---|
| `test_verification_failure_restores_prior_value` | read-back exception restores old secret |
| `test_verification_failure_deletes_partial_write` | read-back exception deletes new partial |
| migrate-success clears old value after verified write | SecretStorage → keyring verified before deletion |
| migrate-failure keeps old value / runtime-never-reads | runtime never reads SecretStorage |
| strip redacts canonical env / spawn env assertions | desktop child env has no PAPERFORGE_CREDENTIAL_* |
| `test_preflight_distinguishes_backend_fault_from_missing` + resolver/diagnostics | backend_locked/unavailable never becomes "API key missing" |

### Evidence
- Python **2988 passed / 296 skipped**; vitest **424/424**; tsc clean; ruff clean

Closes: #173 (reopened).