### PR TITLE
C1 final corrective: migrate legacy profile-hashed embedding SecretStorage id (#173)

### DIFF
--- a/paperforge/credentials.py
+++ b/paperforge/credentials.py
@@ -246,8 +246,12 @@ def store(
 
 def _restore_prior(kr, key: CredentialKey, prior: str | None) -> None:
     """Restore the previous durable value; delete the partial write when
-    there was none.  Best effort — restoration failure is logged nowhere
-    sensitive and never masks the original error."""
+    there was none.
+
+    PaperForge ATTEMPTS the rollback and never reports an unverified write
+    as success.  If the keyring itself fails the rollback too, the value
+    cannot be physically restored at the application layer — the original
+    error is never masked."""
     try:
         if prior is not None and prior != "":
             kr.set_password(SERVICE, key.keyring_username, prior)

--- a/paperforge/embedding/preflight.py
+++ b/paperforge/embedding/preflight.py
@@ -35,13 +35,8 @@ def _preflight_check(vault: Path, settings: dict | None = None) -> dict:
             "error": f"Embedding credential unavailable ({cred_state})",
             "fix": "Run `paperforge auth status embedding` for remediation",
         }
-    from paperforge.credentials import CredentialError as _CredentialError
-    from paperforge.credentials import resolve
-
-    try:
-        api_key = resolve(CredentialKey("embedding"))
-    except _CredentialError:
-        api_key = ""
+    # #173 review: preflight stays a pure presence/status read model — the
+    # secret value is never retrieved here; handlers resolve it.
 
     # 4. OCR done papers
     from paperforge.worker._utils import pipeline_paths

--- a/paperforge/plugin/src/services/secret-storage.ts
+++ b/paperforge/plugin/src/services/secret-storage.ts
@@ -70,10 +70,34 @@ export interface LegacyMigrationResult {
 }
 
 /** Known legacy SecretStorage ids (dash format per Obsidian API). */
-const LEGACY_SECRET_IDS: Record<"ocr" | "embedding", string> = {
-  ocr: "paddleocr-api-key",
-  embedding: "vector-db-api-key",
-};
+const LEGACY_OCR_SECRET_ID = "paddleocr-api-key";
+const LEGACY_EMBEDDING_GLOBAL_ID = "vector-db-api-key";
+
+/**
+ * Legacy profile-scoped embedding id formula — MIGRATION KNOWLEDGE ONLY.
+ * The deleted runtime used `vector-db-api-key-v2-<sha256(baseUrl\0model)>`
+ * for embedding secrets; real old users hold their key under that id, not
+ * the fixed global one.  This must never become a runtime credential
+ * identity again.
+ */
+export async function legacyEmbeddingSecretIds(
+  baseUrl: string,
+  model: string
+): Promise<string[]> {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(
+      `${baseUrl.trim()}\u0000${model.trim() || "text-embedding-3-small"}`
+    )
+  );
+  const digestHex = [...new Uint8Array(digest)]
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+  return [
+    `vector-db-api-key-v2-${digestHex.slice(0, 40)}`,
+    LEGACY_EMBEDDING_GLOBAL_ID,
+  ];
+}
 
 /**
  * #173 corrective: one-time migration of a legacy Obsidian SecretStorage
@@ -85,38 +109,49 @@ const LEGACY_SECRET_IDS: Record<"ocr" | "embedding", string> = {
 export async function migrateLegacySecret(
   kind: "ocr" | "embedding",
   ss: SecretAccess | undefined,
-  deps: MigrationSpawn
+  deps: MigrationSpawn,
+  embeddingProfile?: { baseUrl: string; model: string }
 ): Promise<LegacyMigrationResult> {
   if (!ss || typeof ss.getSecret !== "function") {
     return { migrated: [], warnings: ["SecretStorage unavailable"] };
   }
-  const id = LEGACY_SECRET_IDS[kind];
-  const value = await ss.getSecret(id);
-  if (!value) {
-    return { migrated: [], warnings: [] };
+  // #173 corrective: real old embedding secrets live under the
+  // profile-hashed v2 id — check it (plus the fixed global fallback)
+  // before reporting "no legacy credentials".
+  const ids =
+    kind === "embedding"
+      ? await legacyEmbeddingSecretIds(
+          embeddingProfile?.baseUrl ?? "",
+          embeddingProfile?.model ?? ""
+        )
+      : [LEGACY_OCR_SECRET_ID];
+  for (const id of ids) {
+    const value = await ss.getSecret(id);
+    if (!value) continue;
+    const ok = await _authSetViaSpawn(kind, value, deps);
+    if (!ok) {
+      return {
+        migrated: [],
+        warnings: [
+          "Keyring write failed — the legacy SecretStorage value was kept. " +
+            "Run `paperforge auth set " + kind + " --stdin` manually.",
+        ],
+      };
+    }
+    try {
+      await ss.setSecret(id, "");
+    } catch {
+      return {
+        migrated: [id],
+        warnings: [
+          "Credential migrated and verified, but the old SecretStorage value " +
+            "could not be cleared — delete it manually in Obsidian.",
+        ],
+      };
+    }
+    return { migrated: [id], warnings: [] };
   }
-  const ok = await _authSetViaSpawn(kind, value, deps);
-  if (!ok) {
-    return {
-      migrated: [],
-      warnings: [
-        "Keyring write failed — the legacy SecretStorage value was kept. " +
-          "Run `paperforge auth set " + kind + " --stdin` manually.",
-      ],
-    };
-  }
-  try {
-    await ss.setSecret(id, "");
-  } catch {
-    return {
-      migrated: [id],
-      warnings: [
-        "Credential migrated and verified, but the old SecretStorage value " +
-          "could not be cleared — delete it manually in Obsidian.",
-      ],
-    };
-  }
-  return { migrated: [id], warnings: [] };
+  return { migrated: [], warnings: [] };
 }
 
 function _authSetViaSpawn(

--- a/paperforge/plugin/src/settings.ts
+++ b/paperforge/plugin/src/settings.ts
@@ -4790,7 +4790,13 @@ export class PaperForgeSettingTab extends PluginSettingTab {
       const r = await migrateLegacySecret(
         kind,
         (this.app as unknown as { secretStorage?: { getSecret(id: string): Promise<string | null>; setSecret(id: string, s: string): Promise<void> } }).secretStorage,
-        deps
+        deps,
+        // #173 corrective: real old embedding secrets live under the
+        // profile-hashed v2 id computed from the current endpoint/model.
+        {
+          baseUrl: this.plugin.settings.vector_db_api_base ?? "",
+          model: this.plugin.settings.vector_db_api_model ?? "",
+        }
       );
       if (r.migrated.length) results.push(`${kind}: migrated`);
       for (const w of r.warnings) results.push(w);

--- a/paperforge/plugin/tests/secret-storage.test.ts
+++ b/paperforge/plugin/tests/secret-storage.test.ts
@@ -10,6 +10,7 @@ import {
   stripCredentialEnv,
   isAllowlistedCommand,
   migrateLegacySecret,
+  legacyEmbeddingSecretIds,
   type SecretAccess,
   type MigrationSpawn,
 } from "../src/services/secret-storage";
@@ -152,6 +153,53 @@ describe("migrateLegacySecret (explicit bridge only)", () => {
     const r = await migrateLegacySecret("embedding", ss, depsFor(fake));
     expect(r.migrated).toEqual([]);
     expect(fake.calls.length).toBe(0);
+  });
+
+  it("migrates a profile-hashed legacy embedding secret (real upgrade path)", async () => {
+    // Old runtime stored embedding keys under vector-db-api-key-v2-<hash>.
+    const [hashedId] = await legacyEmbeddingSecretIds(
+      "https://api.openai.com/v1",
+      "text-embedding-3-small"
+    );
+    expect(hashedId).toMatch(/^vector-db-api-key-v2-[0-9a-f]{40}$/);
+    const fake = fakeSpawn({ code: 0, stdout: JSON.stringify({ ok: true }) });
+    const ss: SecretAccess = {
+      getSecret: vi.fn(async (id: string) =>
+        id === hashedId ? "old-embedding-secret" : null
+      ),
+      setSecret: vi.fn(async () => undefined),
+    };
+    const r = await migrateLegacySecret(
+      "embedding",
+      ss,
+      depsFor(fake),
+      { baseUrl: "https://api.openai.com/v1", model: "text-embedding-3-small" }
+    );
+    expect(r.migrated).toEqual([hashedId]);
+    expect(r.warnings).toEqual([]);
+    expect(fake.calls.length).toBe(1);
+    expect(fake.calls[0].args).toContain("embedding");
+    // the old hashed value is cleared after the verified keyring write
+    expect(ss.setSecret).toHaveBeenCalledWith(hashedId, "");
+  });
+
+  it("does not report 'no legacy credentials' when only the hashed id exists", async () => {
+    const [hashedId] = await legacyEmbeddingSecretIds("https://custom/v1", "m");
+    const fake = fakeSpawn({ code: 0, stdout: JSON.stringify({ ok: true }) });
+    const ss: SecretAccess = {
+      getSecret: vi.fn(async (id: string) =>
+        id === hashedId ? "secret" : null
+      ),
+      setSecret: vi.fn(async () => undefined),
+    };
+    const r = await migrateLegacySecret(
+      "embedding",
+      ss,
+      depsFor(fake),
+      { baseUrl: "https://custom/v1", model: "m" }
+    );
+    expect(r.migrated).toEqual([hashedId]); // NOT empty — the fixed global id
+    // was absent but the hashed id carried the value
   });
 
   it("runtime never reads SecretStorage — migration is the only consumer", () => {


### PR DESCRIPTION
## C1 final corrective (review of #180)

The migration bridge checked the fixed `vector-db-api-key` id — but the deleted runtime stored embedding secrets under the **profile-hashed** `vector-db-api-key-v2-<sha256(baseUrl\0model).slice(0,40)>`. Real old users' keys were unreachable. Small fix, migration knowledge only.

### Change
- `legacyEmbeddingSecretIds(baseUrl, model)`: recomputes the historical hashed id (+ the fixed global fallback) — exists ONLY in the migration module, never a runtime credential identity
- Explicit migration passes the current settings profile (base/model)
- preflight: dropped the redundant `resolve()` — pure presence/status read model (T2 boundary)
- `_restore_prior` doc corrected: rollback is attempted; an unverified write is never reported as success; if the keyring itself fails the rollback, the value cannot be physically restored at the app layer

### Tests (2 new)
- profile-hashed legacy embedding secret → keyring → old hashed value cleared
- global id absent + hashed id present → migration must NOT report no-legacy

### Evidence
- Python **2989 passed / 296 skipped**; vitest **426/426**; tsc clean

Closes: #173.