### PR TITLE
T2 corrective: retract T6 chain, confirmation descriptor payload, handler boundary (#163)

### DIFF
--- a/paperforge/actions/registry.py
+++ b/paperforge/actions/registry.py
@@ -186,36 +186,6 @@ def _embed_resume_handler(ctx: ActionContext, request: ActionRequest) -> PFResul
 
 # ── the registry ───────────────────────────────────────────────────────────
 
-ACTION_REGISTRY: Mapping[str, ActionSpec] = {
-    "memory.build": ActionSpec(
-        action_id="memory.build",
-        label_code="action.memory.build",
-        description_code="action.memory.build.description",
-        handler=_memory_build_handler,
-        preflight=_memory_build_preflight,
-        scope_kinds=("all",),
-        cost="local",
-        impact="mutating",
-        confirmation="none",
-        automatic=True,
-        interruptible=True,
-    ),
-    "embed.resume": ActionSpec(
-        action_id="embed.resume",
-        label_code="action.embed.resume",
-        description_code="action.embed.resume.description",
-        handler=_embed_resume_handler,
-        preflight=_embed_resume_preflight,
-        scope_kinds=("all",),
-        cost="remote_possible",
-        impact="mutating",
-        confirmation="required",
-        automatic=False,
-        interruptible=True,
-    ),
-}
-
-
 def validate_registry(registry: Mapping[str, ActionSpec] | None = None) -> list[str]:
     """Registry invariant audit; empty list = valid."""
     problems: list[str] = []
@@ -253,6 +223,59 @@ def validate_registry(registry: Mapping[str, ActionSpec] | None = None) -> list[
     return problems
 
 
+_SPECS: tuple[ActionSpec, ...] = (
+    ActionSpec(
+        action_id="memory.build",
+        label_code="action.memory.build",
+        description_code="action.memory.build.description",
+        handler=_memory_build_handler,
+        preflight=_memory_build_preflight,
+        scope_kinds=("all",),
+        cost="local",
+        impact="mutating",
+        confirmation="none",
+        automatic=True,
+        interruptible=True,
+    ),
+    ActionSpec(
+        action_id="embed.resume",
+        label_code="action.embed.resume",
+        description_code="action.embed.resume.description",
+        handler=_embed_resume_handler,
+        preflight=_embed_resume_preflight,
+        scope_kinds=("all",),
+        cost="remote_possible",
+        impact="mutating",
+        confirmation="required",
+        automatic=False,
+        interruptible=True,
+    ),
+)
+
+
+class RegistryError(RuntimeError):
+    """Raised at import time when the frozen table violates an invariant."""
+
+
+def _build_registry(specs: tuple[ActionSpec, ...]) -> dict[str, ActionSpec]:
+    """Build the lookup dict from the literal tuple — duplicate ids are
+    detectable here (a literal dict would silently overwrite) and invariant
+    violations fail loudly instead of being recorded for later."""
+    table: dict[str, ActionSpec] = {}
+    for spec in specs:
+        if spec.action_id in table:
+            raise RegistryError(f"duplicate action id: {spec.action_id}")
+        problems = validate_registry({spec.action_id: spec})
+        if problems:
+            raise RegistryError(f"invalid action {spec.action_id}: {'; '.join(problems)}")
+        table[spec.action_id] = spec
+    return table
+
+
+ACTION_REGISTRY: Mapping[str, ActionSpec] = _build_registry(_SPECS)
+
+
+
 def emit_next_action(intent: ActionIntent) -> object:
     """#145 §5.2: registry hydration of an emission-time intent into the
     next_actions v1 wire model.  Unknown action ids fail closed.  The wire
@@ -277,8 +300,5 @@ def emit_next_action(intent: ActionIntent) -> object:
     )
 
 
-_REGISTRY_PROBLEMS = validate_registry()
 
 
-def get_registry_problems() -> list[str]:
-    return list(_REGISTRY_PROBLEMS)

--- a/paperforge/actions/runner.py
+++ b/paperforge/actions/runner.py
@@ -1,14 +1,16 @@
-"""Generic action runner (#163 / T2, #145 §6–§8).
+"""Generic action runner (#163 / T2, #145 §6).
 
 Pipeline: registry lookup fail-closed → scope validation → preflight →
-confirmation gate → handler → single PFResult (+ optional follow-up chain).
-The runner performs no retries, never invokes a shell, and never spawns
-`paperforge` recursively.
+confirmation gate → handler → single PFResult.
+
+The follow-up chain (--follow auto, dedupe, MAX_FOLLOW_UP_DEPTH, child
+execution) is T6 (#167) scope — T2 ships `--follow none` only: the root
+handler's next_actions are returned unchanged.
 """
 
 from __future__ import annotations
 
-import json
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
@@ -19,13 +21,10 @@ from paperforge.actions.types import (
     ActionRequest,
     ActionScope,
     ActionSpec,
-    PapersScope,
     PreflightResult,
 )
 from paperforge.core.errors import ErrorCode
 from paperforge.core.result import PFError, PFResult
-
-MAX_FOLLOW_UP_DEPTH = 4
 
 SCHEMA_VERSION = 1
 
@@ -45,16 +44,21 @@ class ActionError(RuntimeError):
 
 
 def build_context(vault: Path) -> ActionContext:
-    """ActionContext from the existing CLI context plumbing (C0 seam)."""
-    from paperforge.config import load_vault_config, resolve_paths
+    """ActionContext from ONE config snapshot (C0 seam): both the config
+    values and the resolved paths derive from the same snapshot, so the
+    context is a frozen invocation view."""
+    from paperforge.config import load_config, resolve_paths
 
     try:
-        config = load_vault_config(vault)
-        paths = resolve_paths(vault)
+        snapshot = load_config(vault)
+        values: dict[str, object] = {
+            key: cv.value for key, cv in snapshot.values.items()
+        }
+        paths = resolve_paths(vault, snapshot)
     except Exception:  # noqa: BLE001 — fail-closed context
-        config = {}
+        values = {}
         paths = {}
-    return ActionContext(vault=vault, config=config, paths=paths)
+    return ActionContext(vault=vault, config=values, paths=paths)
 
 
 def descriptor_for(
@@ -134,14 +138,20 @@ def _require_available(preflight: PreflightResult) -> None:
 def _require_confirmation(
     spec: ActionSpec,
     confirmed_action_id: str | None,
+    *,
+    descriptor: dict[str, Any],
 ) -> None:
     if spec.confirmation != "required":
         return
     if confirmed_action_id is None:
+        # #163: exit 3 carries the CURRENT action descriptor — the caller
+        # renders availability + preservation/replacement facts, then
+        # re-runs with --confirm.
         raise ActionError(
             ErrorCode.ACTION_CONFIRMATION_REQUIRED.value,
             f"confirmation required — rerun with --confirm {spec.action_id}",
             exit_code=3,
+            data=descriptor,
         )
     if confirmed_action_id != spec.action_id:
         raise ActionError(
@@ -157,31 +167,65 @@ def run_action(
     *,
     confirmed_action_id: str | None = None,
 ) -> PFResult:
-    """The #145 §6 pipeline for one action.  Raises ActionError pre-dispatch;
-    handler failures become structured PFResults."""
+    """The #145 §6 pipeline for one action.
+
+    Raises ActionError pre-dispatch.  Handler failures are converted to
+    structured PFResult errors at the runner boundary — a dispatched action
+    always produces exactly one PFResult (rc 0/1/130), never a traceback.
+    """
     spec = _require_registered(request.action_id)
     validate_scope(spec, request.scope)
     preflight = spec.preflight(context, request)
     _require_available(preflight)
-    _require_confirmation(spec, confirmed_action_id)
-    return spec.handler(context, request)
+    descriptor = descriptor_for(spec, request, preflight)
+    _require_confirmation(spec, confirmed_action_id, descriptor=descriptor)
+    try:
+        result = spec.handler(context, request)
+    except KeyboardInterrupt:
+        # #137: the cancellation path owns this — re-raise for rc130.
+        raise
+    except Exception as exc:  # noqa: BLE001 — structured error boundary
+        from paperforge import __version__ as PF_VERSION
+
+        return PFResult(
+            ok=False,
+            command="action run",
+            version=PF_VERSION,
+            error=PFError(code=ErrorCode.INTERNAL_ERROR, message=str(exc)),
+        )
+    return _validate_handler_result(result, spec.action_id)
 
 
-def canonical_dedupe_key(action_id: str, scope: ActionScope) -> str:
-    """One dedupe authority: normalized action_id + scope."""
-    if scope.kind == "papers":
-        normalized = PapersScope(tuple(sorted(set(scope.keys))))
-        payload = {"action_id": action_id, "scope": _scope_payload(normalized)}
-    else:
-        payload = {"action_id": action_id, "scope": {"kind": "all"}}
-    return json.dumps(payload, sort_keys=True)
+def _validate_handler_result(result: Any, action_id: str) -> PFResult:
+    """#145 Rev3 guard: handlers MUST return PFResult with data mapping/None."""
+    from paperforge import __version__ as PF_VERSION
+
+    if not isinstance(result, PFResult):
+        return PFResult(
+            ok=False,
+            command="action run",
+            version=PF_VERSION,
+            error=PFError(
+                code=ErrorCode.INTERNAL_ERROR,
+                message=f"handler for {action_id} returned {type(result).__name__}, not PFResult",
+            ),
+        )
+    if result.data is not None and not isinstance(result.data, Mapping):
+        return PFResult(
+            ok=False,
+            command="action run",
+            version=PF_VERSION,
+            error=PFError(
+                code=ErrorCode.INTERNAL_ERROR,
+                message=f"handler for {action_id} returned non-mapping data: {type(result.data).__name__}",
+            ),
+        )
+    return result
 
 
 def hydrate_from_registry(intent: ActionIntent) -> dict[str, Any]:
     """Hydrate an emission-time intent into a wire descriptor (registry
     projection).  Unknown ids fail closed."""
-    from paperforge.actions.types import scope_from_dict
-
     spec = _require_registered(intent.action_id)
     return {
         "schema_version": SCHEMA_VERSION,
@@ -195,86 +239,6 @@ def hydrate_from_registry(intent: ActionIntent) -> dict[str, Any]:
         "confirmation": spec.confirmation,
         "reason": intent.trigger_reason,
     }
-
-
-def run_follow_up_chain(
-    root_result: PFResult,
-    context: ActionContext,
-    *,
-    mode: str,
-) -> PFResult:
-    """§8.2: per-invocation dedupe + depth-bounded follow-up execution.
-
-    `mode` is "none" (default) or "auto".  Only automatic local descendants
-    execute; confirmation-required descendants are returned as pending.
-    """
-    root_next = list(root_result.next_actions)
-    if mode == "none" or not root_next:
-        return root_result
-
-    executed: list[dict[str, Any]] = []
-    pending: list[dict[str, Any]] = []
-    skipped: list[dict[str, Any]] = []
-    seen: set[str] = set()
-
-    queue: list[tuple[int, dict[str, Any]]] = [
-        (1, item) for item in root_next if isinstance(item, dict)
-    ]
-    while queue:
-        depth, raw_intent = queue.pop(0)
-        try:
-            action_id = str(raw_intent["action_id"])
-            from paperforge.actions.types import scope_from_dict
-
-            scope = scope_from_dict(dict(raw_intent["scope"]))
-        except (KeyError, TypeError, ValueError):
-            skipped.append({"action_id": "unknown", "reason_code": "action.invalid_intent"})
-            continue
-        key = canonical_dedupe_key(action_id, scope)
-        if key in seen:
-            skipped.append({"action_id": action_id, "reason_code": "action.duplicate"})
-            continue
-        seen.add(key)
-        if depth > MAX_FOLLOW_UP_DEPTH:
-            skipped.append({"action_id": action_id, "reason_code": "action.depth_exceeded"})
-            continue
-
-        spec = ACTION_REGISTRY.get(action_id)
-        if spec is None:
-            skipped.append({"action_id": action_id, "reason_code": "action.unknown"})
-            continue
-        if not (spec.automatic and spec.cost == "local" and spec.confirmation == "none"):
-            pending.append({"action_id": action_id, "scope": _scope_payload(scope)})
-            continue
-
-        child_request = ActionRequest(action_id=action_id, scope=scope)
-        try:
-            child = run_action(child_request, context)
-        except ActionError as exc:
-            skipped.append({"action_id": action_id, "reason_code": exc.code})
-            continue
-        executed.append({"action_id": action_id, "ok": child.ok})
-        for item in child.next_actions:
-            if isinstance(item, dict):
-                queue.append((depth + 1, item))
-
-    # The outer result keeps only the actions still pending after the
-    # selected mode; the execution report lives under data.follow_up_execution
-    # (#145 §8.3).  With --follow none nothing executed, so everything stays.
-    root_result.next_actions = [dict(item) for item in pending]
-    data = root_result.data
-    if data is None:
-        data = {}
-    if isinstance(data, dict):
-        data = dict(data)
-        data["follow_up_execution"] = {
-            "executed": executed,
-            "pending": pending,
-            "skipped": skipped,
-        }
-    root_result.data = data
-    return root_result
-
 
 
 def cancelled_result(command: str, message: str) -> PFResult:

--- a/paperforge/cli.py
+++ b/paperforge/cli.py
@@ -537,7 +537,8 @@ def build_parser() -> argparse.ArgumentParser:
     p_action_run.add_argument("--scope", choices=["all", "papers"], default="all", help="Request scope kind (papers needs --key)")
     p_action_run.add_argument("--key", action="append", default=[], metavar="KEY", help="Paper key (papers scope; repeatable)")
     p_action_run.add_argument("--confirm", default=None, help="Exact action id to confirm (confirmation-required actions)")
-    p_action_run.add_argument("--follow", choices=["none", "auto"], default="none", help="Follow-up mode (#145 §8.1)")
+    # T2: --follow none only — the follow-up chain (--follow auto) is T6 (#167) scope.
+    p_action_run.add_argument("--follow", choices=["none"], default="none", help="Follow-up mode (T6 adds auto)")
     p_action_run.add_argument("--json", action="store_true", help="Output as JSON")
 
     # ── auth family (#173 / C1) ──

--- a/paperforge/commands/action.py
+++ b/paperforge/commands/action.py
@@ -18,7 +18,6 @@ from paperforge.actions.runner import (
     build_context,
     descriptor_for,
     run_action,
-    run_follow_up_chain,
 )
 from paperforge.actions.types import (
     ActionRequest,
@@ -105,9 +104,11 @@ def _parse_scope(args: argparse.Namespace) -> ActionScope:
 
 
 def run_dispatch(args: argparse.Namespace) -> int:
-    """`action run` — the #145 §6 pipeline with exit-code mapping."""
+    """`action run` — the #145 §6 pipeline with exit-code mapping.
+
+    T2 ships --follow none only: the root handler's next_actions are
+    returned unchanged.  The follow-up chain lands with T6 (#167)."""
     json_output = bool(getattr(args, "json", False))
-    follow = getattr(args, "follow", "none")
     action_id = args.action_id
     confirmed = getattr(args, "confirm", None)
     context = build_context(args.vault_path)
@@ -115,8 +116,6 @@ def run_dispatch(args: argparse.Namespace) -> int:
 
     try:
         result = run_action(request, context, confirmed_action_id=confirmed)
-        if follow != "none":
-            result = run_follow_up_chain(result, context, mode=follow)
     except ActionError as exc:
         result = _error_result("action run", exc.code, str(exc), data=exc.data)
         if json_output:

--- a/tests/test_action_registry.py
+++ b/tests/test_action_registry.py
@@ -11,13 +11,10 @@ import pytest
 
 from paperforge.actions.registry import ACTION_REGISTRY, emit_next_action, validate_registry
 from paperforge.actions.runner import (
-    MAX_FOLLOW_UP_DEPTH,
     ActionError,
-    canonical_dedupe_key,
     descriptor_for,
     hydrate_from_registry,
     run_action,
-    run_follow_up_chain,
 )
 from paperforge.actions.types import (
     ActionContext,
@@ -176,6 +173,14 @@ class TestRunnerPipeline:
             run_action(ActionRequest("test.confirm", AllScope()), _ctx(tmp_path))
         assert exc.value.code == ErrorCode.ACTION_CONFIRMATION_REQUIRED.value
         assert exc.value.exit_code == 3
+        # #163 corrective: exit 3 carries the CURRENT action descriptor.
+        data = exc.value.data
+        assert isinstance(data, dict)
+        assert data["action_id"] == "test.confirm"
+        assert data["confirmation"] == "required"
+        assert data["availability"] == "available"
+        assert "preservation_facts" in data and "replacement_facts" in data
+        assert "command" not in data and "argv" not in data
 
     def test_confirm_mismatch_is_invalid_request(self, tmp_path: Path, _registry) -> None:
         _registry(_spec("test.confirm", confirmation="required", automatic=False, cost="remote_possible"))
@@ -216,104 +221,98 @@ class TestRunnerPipeline:
         result = run_action(ActionRequest("test.ok", AllScope()), _ctx(tmp_path))
         assert result.ok and called == ["test.ok"]
 
+    def test_next_actions_returned_unchanged(self, tmp_path: Path, _registry) -> None:
+        """T2 ships --follow none: the root handler's next_actions pass
+        through untouched (the follow-up chain is T6 scope)."""
+        def handler(ctx, req):
+            result = _ok_result()
+            result.next_actions = [
+                emit_next_action(
+                    ActionIntent("embed.resume", AllScope(), "vector.pending", "pending")
+                ).to_dict()
+            ]
+            return result
+
+        _registry(_spec("test.emits", handler=handler))
+        result = run_action(ActionRequest("test.emits", AllScope()), _ctx(tmp_path))
+        assert result.ok
+        assert [n["action_id"] for n in result.next_actions] == ["embed.resume"]
+        # v1 wire fields are intact (automatic/cost/impact/confirmation/reason)
+        item = result.next_actions[0]
+        assert item["automatic"] is False
+        assert item["cost"] == "remote_possible"
+        assert item["confirmation"] == "required"
+        assert item["reason"] == "pending"
+        assert "dedupe_key" not in item
+        assert "follow_up_execution" not in (result.data or {})
+
     def test_handler_exceptions_become_structured_errors(self, tmp_path: Path, _registry) -> None:
+        """#163 corrective: a dispatched action always yields exactly one
+        PFResult — handler exceptions convert at the runner boundary, never
+        a traceback."""
         def handler(ctx, req):
             raise RuntimeError("domain boom")
 
         _registry(_spec("test.boom", handler=handler))
-        # #145 §6.5: the runner boundary converts exceptions to PFResult errors.
-        with pytest.raises(RuntimeError, match="domain boom"):
-            run_action(ActionRequest("test.boom", AllScope()), _ctx(tmp_path))
+        result = run_action(ActionRequest("test.boom", AllScope()), _ctx(tmp_path))
+        assert result.ok is False
+        assert result.error is not None
+        assert result.error.code.value == "INTERNAL_ERROR"
+        assert "domain boom" in result.error.message
 
-    def test_dedupe_identity_normalizes_keys(self) -> None:
-        assert canonical_dedupe_key("memory.build", PapersScope(("B", "A", "B"))) == canonical_dedupe_key(
-            "memory.build", PapersScope(("A", "B"))
-        )
-        assert canonical_dedupe_key("memory.build", AllScope()) != canonical_dedupe_key(
-            "memory.build", PapersScope(("A",))
-        )
+    def test_handler_keyboard_interrupt_propagates_to_cancellation(self, tmp_path: Path, _registry) -> None:
+        """#137: KeyboardInterrupt is NOT folded into a structured error —
+        it propagates to the CLI's rc130 cancellation path."""
+        def handler(ctx, req):
+            raise KeyboardInterrupt("cancelled")
+
+        _registry(_spec("test.cancel", handler=handler))
+        with pytest.raises(KeyboardInterrupt):
+            run_action(ActionRequest("test.cancel", AllScope()), _ctx(tmp_path))
+
+    def test_non_mapping_handler_data_rejected(self, tmp_path: Path, _registry) -> None:
+        """#145 Rev3: PFResult.data must be a mapping or None."""
+        def handler(ctx, req):
+            return PFResult(ok=True, command="action run", version="t", data="not-a-mapping")
+
+        _registry(_spec("test.baddata", handler=handler))
+        result = run_action(ActionRequest("test.baddata", AllScope()), _ctx(tmp_path))
+        assert result.ok is False
+        assert "non-mapping data" in (result.error.message if result.error else "")
+
+    def test_non_pfresult_handler_return_rejected(self, tmp_path: Path, _registry) -> None:
+        def handler(ctx, req):
+            return {"ok": True}  # type: ignore[return-value]
+
+        _registry(_spec("test.badreturn", handler=handler))
+        result = run_action(ActionRequest("test.badreturn", AllScope()), _ctx(tmp_path))
+        assert result.ok is False
+        assert "not PFResult" in (result.error.message if result.error else "")
 
 
 # ── follow-up chain ────────────────────────────────────────────────────────
 
-class TestFollowUpChain:
-    def test_follow_none_leaves_next_actions_pending(self, tmp_path: Path) -> None:
-        root = _ok_result()
-        root.next_actions = [
-            emit_next_action(
-                ActionIntent("embed.resume", AllScope(), "vector.pending", "pending")
-            ).to_dict()
-        ]
-        result = run_follow_up_chain(root, _ctx(tmp_path), mode="none")
-        assert [n["action_id"] for n in result.next_actions] == ["embed.resume"]
-        assert "follow_up_execution" not in (result.data or {})
+class TestContext:
+    def test_build_context_from_single_snapshot(self, tmp_path: Path) -> None:
+        """#163 corrective: config values and paths derive from ONE config
+        snapshot — the context is a frozen invocation view (C0 seam)."""
+        from paperforge.actions.runner import build_context
 
-    def test_follow_auto_keeps_confirmation_required_pending(self, tmp_path: Path) -> None:
-        root = _ok_result()
-        root.next_actions = [
-            emit_next_action(
-                ActionIntent("embed.resume", AllScope(), "vector.pending", "pending")
-            ).to_dict()
-        ]
-        result = run_follow_up_chain(root, _ctx(tmp_path), mode="auto")
-        data = result.data or {}
-        assert data["follow_up_execution"]["pending"] == [
-            {"action_id": "embed.resume", "scope": {"kind": "all"}}
-        ]
-        assert data["follow_up_execution"]["executed"] == []
-        # the outer wire keeps only pending actions
-        assert [n["action_id"] for n in result.next_actions] == ["embed.resume"]
+        vault = tmp_path / "vault"
+        vault.mkdir(parents=True)
+        canonical_test_config(vault, system_dir="99_System")
+        ctx = build_context(vault)
+        assert ctx.config.get("system_dir") == "99_System"
+        assert str(ctx.paths.get("ocr", "")) == str(vault / "99_System" / "PaperForge" / "ocr")
 
-    def test_follow_auto_executes_automatic_local_descendants(self, tmp_path: Path, _registry) -> None:
-        called: list[str] = []
+    def test_build_context_fails_closed_without_config(self, tmp_path: Path) -> None:
+        from paperforge.actions.runner import build_context
 
-        def handler(ctx, req):
-            called.append(req.action_id)
-            return _ok_result()
+        vault = tmp_path / "novault"
+        ctx = build_context(vault)
+        assert ctx.config == {}
+        assert ctx.paths == {}
 
-        _registry(_spec("test.auto", handler=handler))
-        root = _ok_result()
-        root.next_actions = [
-            emit_next_action(
-                ActionIntent("test.auto", AllScope(), "t", "why")
-            ).to_dict()
-        ]
-        result = run_follow_up_chain(root, _ctx(tmp_path), mode="auto")
-        assert called == ["test.auto"]
-        data = result.data or {}
-        assert data["follow_up_execution"]["executed"] == [{"action_id": "test.auto", "ok": True}]
-        assert [n["action_id"] for n in result.next_actions] == []
-
-    def test_depth_bounded(self, tmp_path: Path, _registry) -> None:
-        """A linear chain of distinct actions is bounded by the depth
-        constant; the overflowing descendant is skipped with depth_exceeded."""
-        chain = [f"test.d{i}" for i in range(1, MAX_FOLLOW_UP_DEPTH + 2)]
-
-        def chain_handler(next_id: str):
-            def handler(ctx, req):
-                result = _ok_result()
-                if next_id:
-                    result.next_actions = [
-                        emit_next_action(ActionIntent(next_id, AllScope(), "t", "why")).to_dict()
-                    ]
-                return result
-            return handler
-
-        for i, action_id in enumerate(chain):
-            nxt = chain[i + 1] if i + 1 < len(chain) else ""
-            _registry(_spec(action_id, handler=chain_handler(nxt)))
-
-        root = _ok_result()
-        root.next_actions = [
-            emit_next_action(ActionIntent(chain[0], AllScope(), "t", "why")).to_dict()
-        ]
-        result = run_follow_up_chain(root, _ctx(tmp_path), mode="auto")
-        data = result.data or {}
-        assert len(data["follow_up_execution"]["executed"]) == MAX_FOLLOW_UP_DEPTH
-        assert data["follow_up_execution"]["skipped"][-1]["reason_code"] == "action.depth_exceeded"
-
-
-# ── descriptors and wire ───────────────────────────────────────────────────
 
 class TestDescriptorWire:
     def test_descriptor_has_no_command_or_argv(self) -> None:
@@ -393,6 +392,35 @@ class TestCliExitCodes:
         assert rc == 1
         assert payload["error"]["code"] == "action.unavailable"
         assert payload["data"]["availability_reason_code"] == "credential.missing"
+
+    def test_confirmation_required_cli_exit_3_with_descriptor(self, tmp_path: Path, monkeypatch) -> None:
+        """#163 acceptance: without --confirm, a confirmation-required action
+        exits 3 and the payload data IS the current action descriptor."""
+        monkeypatch.setenv("PAPERFORGE_CREDENTIAL_EMBEDDING__DEFAULT", "test-token")
+        rc, payload = _run_cli("--vault", str(tmp_path), "action", "run", "embed.resume", "--json")
+        assert rc == 3
+        assert payload["error"]["code"] == "action.confirmation_required"
+        data = payload["data"]
+        assert data["action_id"] == "embed.resume"
+        assert data["scope"] == {"kind": "all"}
+        assert data["availability"] == "available"
+        assert data["cost"] == "remote_possible"
+        assert data["impact"] == "mutating"
+        assert data["confirmation"] == "required"
+        assert data["preservation_facts"] and data["replacement_facts"]
+        assert "command" not in data and "argv" not in data
+
+    def test_confirmed_dispatch_executes(self, tmp_path: Path, monkeypatch) -> None:
+        """--confirm with the exact id executes; the embed handler runs to
+        its structured result (missing index -> error rc1 in this vault)."""
+        monkeypatch.setenv("PAPERFORGE_CREDENTIAL_EMBEDDING__DEFAULT", "test-token")
+        rc, payload = _run_cli(
+            "--vault", str(tmp_path), "action", "run", "embed.resume",
+            "--confirm", "embed.resume", "--json",
+        )
+        # Dispatched: rc is 0 or 1 (structured result), never 2/3.
+        assert rc in (0, 1)
+        assert "error" in payload or payload["ok"] is True
 
     def test_cancelled_dispatch_is_rc130(self, tmp_path: Path) -> None:
         """#137: a cancelled dispatch reports a cancelled terminal, never rc1."""


### PR DESCRIPTION
## T2 corrective closure (review of #182)

### P0-1 — T6 scope retracted from T2
The follow-up chain (--follow auto, canonical dedupe, MAX_FOLLOW_UP_DEPTH, automatic descendant execution, executed/pending/skipped) belongs to T6 (#167) per the frozen DAG. Removed from T2: `action run` ships `--follow none` only, and the root handler's next_actions pass through untouched (v1 wire intact — automatic/cost/impact/confirmation/reason preserved). T6 re-lands the chain from the frozen #145 §8 spec. memory.build → embed.resume dependency-by-emission stays (frozen in #145 Rev3).

### P0-2 — exit 3 now carries the current ActionDescriptor
Preflight runs first, then the confirmation gate raises with the descriptor as data: action_id/scope/availability/cost/impact/confirmation/preservation_facts/replacement_facts. CLI-level JSON test added (not just exit_code assertions).

### P0-3 — handler single-PFResult boundary
A dispatched action always yields exactly one PFResult: handler exceptions convert at the runner boundary (INTERNAL_ERROR, rc1); KeyboardInterrupt re-raises to the rc130 cancellation path. The old test that asserted a raw RuntimeError propagation is replaced by the structured-error contract.

### P1 — contract guards
- PFResult.data runtime guard: handlers returning non-PFResult or non-mapping data get a structured rc1
- ActionContext derives config values AND resolved paths from ONE load_config snapshot
- Registry hardening: ACTION_REGISTRY built from the literal _SPECS tuple — duplicate ids / invariant violations raise RegistryError at import time (a literal dict silently overwrote duplicates)

### Tests
32 action tests: passthrough-next_actions (v1 wire intact), confirmation descriptor payload (runner + CLI), structured handler errors, KeyboardInterrupt propagation, data guards, single-snapshot context, import-time duplicate rejection.

### Evidence
- Python **3021 passed / 296 skipped**; ruff clean; vitest unaffected

Closes: #163.