### PR TITLE
T3: memory build papers-scope seam (#164)

### DIFF
--- a/paperforge/actions/registry.py
+++ b/paperforge/actions/registry.py
@@ -13,6 +13,7 @@ from paperforge.actions.types import (
     ActionContext,
     ActionIntent,
     ActionRequest,
+    ActionScope,
     ActionSpec,
     AllScope,
     PreflightResult,
@@ -24,7 +25,9 @@ from paperforge.core.result import PFResult
 
 
 def _memory_build_preflight(ctx: ActionContext, request: ActionRequest) -> PreflightResult:
-    """memory.build availability: canonical config + library index present."""
+    """memory.build availability: canonical config + library index present;
+    papers scope additionally validates keys against the canonical index
+    (unknown key = invalid scope, exit 2)."""
     from paperforge.worker.asset_index import read_index
 
     if not ctx.config:
@@ -33,12 +36,26 @@ def _memory_build_preflight(ctx: ActionContext, request: ActionRequest) -> Prefl
             availability_reason_code="action.config_missing",
             availability_reason="Canonical configuration is missing — run `paperforge config init`",
         )
-    if read_index(ctx.vault) is None:
+    index = read_index(ctx.vault)
+    if index is None:
         return PreflightResult(
             availability="unavailable",
             availability_reason_code="action.library_index_missing",
             availability_reason="formal-library.json is missing — run `paperforge sync --rebuild-index`",
         )
+    if request.scope.kind == "papers":
+        items = index.get("items") if isinstance(index, dict) else index
+        canonical_keys = {e["zotero_key"] for e in items or [] if e.get("zotero_key")}
+        unknown = sorted(set(request.scope.keys) - canonical_keys)
+        if unknown:
+            from paperforge.actions.runner import ActionError
+            from paperforge.core.errors import ErrorCode
+
+            raise ActionError(
+                ErrorCode.ACTION_SCOPE_INVALID.value,
+                f"unknown paper keys: {unknown}",
+                exit_code=2,
+            )
     return PreflightResult(
         availability="available",
         availability_reason_code="action.available",
@@ -54,8 +71,11 @@ def _memory_build_handler(ctx: ActionContext, request: ActionRequest) -> PFResul
     from paperforge.core.result import PFError, PFResult
     from paperforge.memory.builder import build_from_index
 
+    keys = None if request.scope.kind == "all" else list(request.scope.keys)
+    from paperforge.memory.builder import build_for_keys
+
     try:
-        counts = build_from_index(ctx.vault)
+        counts = build_for_keys(ctx.vault, keys)
     except FileNotFoundError as exc:
         return PFResult(
             ok=False,
@@ -64,12 +84,16 @@ def _memory_build_handler(ctx: ActionContext, request: ActionRequest) -> PFResul
             error=PFError(code=ErrorCode.PATH_NOT_FOUND, message=str(exc)),
         )
     result = PFResult(ok=True, command="action run", version=PF_VERSION, data=counts)
-    # §8.1b dependency-by-emission: memory.build emits embed.resume on success.
+    # §8.1b dependency-by-emission: memory.build emits embed.resume on
+    # success — scoped builds carry the same keys (T6 wires the chain).
+    from paperforge.actions.types import PapersScope
+
+    follow_scope: ActionScope = PapersScope(tuple(keys)) if keys else AllScope()
     result.next_actions = [
         emit_next_action(
             ActionIntent(
                 action_id="embed.resume",
-                scope=AllScope(),
+                scope=follow_scope,
                 trigger_reason_code="vector.pending_after_memory_build",
                 trigger_reason="Memory changed — vector rows may need rebuilding",
             )
@@ -230,7 +254,7 @@ _SPECS: tuple[ActionSpec, ...] = (
         description_code="action.memory.build.description",
         handler=_memory_build_handler,
         preflight=_memory_build_preflight,
-        scope_kinds=("all",),
+        scope_kinds=("all", "papers"),
         cost="local",
         impact="mutating",
         confirmation="none",

--- a/paperforge/cli.py
+++ b/paperforge/cli.py
@@ -333,6 +333,8 @@ def build_parser() -> argparse.ArgumentParser:
     p_memory = sub.add_parser("memory", help="Manage the Memory Layer")
     p_memory_sp = p_memory.add_subparsers(dest="memory_subcommand", required=True)
     p_memory_build = p_memory_sp.add_parser("build", help="Build the memory database from canonical index")
+    p_memory_build.add_argument("--key", action="append", default=[], metavar="KEY",
+                               help="Paper key to build (repeatable; papers scope)")
     p_memory_build.add_argument("--json", action="store_true", help="Output as JSON")
     p_memory_status = p_memory_sp.add_parser("status", help="Check memory database status")
     p_memory_status.add_argument("--json", action="store_true", help="Output as JSON")

--- a/paperforge/commands/memory.py
+++ b/paperforge/commands/memory.py
@@ -162,7 +162,10 @@ def run(args: argparse.Namespace) -> int:
 
     if sub_cmd == "build":
         try:
-            counts = build_from_index(vault)
+            keys = getattr(args, "key", None) or None
+            from paperforge.memory.builder import build_for_keys
+
+            counts = build_for_keys(vault, keys)
             result = PFResult(
                 ok=True,
                 command="memory build",
@@ -185,6 +188,22 @@ def run(args: argparse.Namespace) -> int:
                     }
                 ],
             )
+        except ValueError as exc:
+            # #164/T3: unknown paper keys = invalid scope, exit 2.
+            result = PFResult(
+                ok=False,
+                command="memory build",
+                version=PF_VERSION,
+                error=PFError(
+                    code=ErrorCode.ACTION_SCOPE_INVALID,
+                    message=str(exc),
+                ),
+            )
+            if args.json:
+                print(result.to_json())
+            else:
+                print(str(exc), file=sys.stderr)
+            return 2
         except Exception as exc:
             result = PFResult(
                 ok=False,

--- a/paperforge/memory/builder.py
+++ b/paperforge/memory/builder.py
@@ -260,26 +260,40 @@ def _delete_paper(conn: sqlite3.Connection, vault: Path, key: str) -> None:
     # 3. Papers last
     conn.execute("DELETE FROM papers WHERE zotero_key=?", (key,))
 
-def build_from_index(vault: Path) -> dict:
-    """Read formal-library.json and build/rebuild paperforge.db.
+def build_for_keys(vault: Path, keys: list[str] | None = None) -> dict:
+    """#164/T3: build paperforge.db for canonical paper keys.
 
-    Acquires the cross-process writer lock for the whole build (D2) — a
-    shadow vector rebuild must not be racing a memory build that mutates
-    the same live DB (the shadow snapshot would be stale at publish).
+    ``keys=None`` → current whole-library build (unchanged behavior).
+    ``keys`` given → a scope-faithful build: side effects are restricted to
+    the requested keys (affected_keys ⊆ requested_keys).  Unknown keys raise
+    ``ValueError`` — callers translate to exit 2.  A scoped request on a
+    fresh/destructive DB still full-rebuilds the whole library (the DB must
+    stay internally consistent); scope fidelity holds on an existing DB.
+
+    Acquires the cross-process writer lock for the whole build (D2).
     """
     from paperforge.memory.db import WriterLock
 
     with WriterLock(vault):
-        return _build_from_index_locked(vault)
+        return _build_from_index_locked(vault, keys=keys)
 
 
-def _build_from_index_locked(vault: Path) -> dict:
+def build_from_index(vault: Path) -> dict:
+    """Read formal-library.json and build/rebuild paperforge.db (all keys)."""
+    return build_for_keys(vault, None)
+
+
+def _build_from_index_locked(vault: Path, keys: list[str] | None = None) -> dict:
     """Build/rebuild paperforge.db (writer lock already held).
 
     Scheduling:
     1. Schema migration (destructive → full rebuild).
     2. Global hash unchanged → skip (fast path).
     3. Per-paper incremental: diff → delete → upsert → units.
+
+    ``keys``: scoped build (#164/T3) — validate against canonical index keys
+    (unknown → ValueError), filter items, never delete, and restrict the
+    correction-event rewrite to the requested keys.
     """
     envelope = read_index(vault)
     if envelope is None:
@@ -317,6 +331,15 @@ def _build_from_index_locked(vault: Path) -> dict:
             conn.close()
             return result
 
+        # ── 2.5 Scoped build: validate keys against the canonical index and
+        #      filter — everything below schedules over the filtered set ──
+        if keys is not None:
+            canonical_keys = {e["zotero_key"] for e in items if e.get("zotero_key")}
+            unknown = sorted(set(keys) - canonical_keys)
+            if unknown:
+                raise ValueError(f"unknown paper keys: {unknown}")
+            items = [e for e in items if e.get("zotero_key") in set(keys)]
+
         # ── 3. Global hash unchanged + no schema change → fast path ──────
         if migration_action == "none" and canonical_hash and db_path.exists():
             try:
@@ -338,9 +361,12 @@ def _build_from_index_locked(vault: Path) -> dict:
         # ── 4. Per-paper incremental ─────────────────────────────────────
         diff = _diff_paper_state(conn, items)
 
-        # 4a. Delete removed papers
-        for key in diff["deleted"]:
-            _delete_paper(conn, vault, key)
+        # 4a. Delete removed papers — NEVER in a scoped build: every
+        #     requested key is present in the index (validated in 2.5), so a
+        #     scoped diff would mass-delete every non-requested paper.
+        if keys is None:
+            for key in diff["deleted"]:
+                _delete_paper(conn, vault, key)
 
         # 4b. Upsert changed / added papers
         now_utc = datetime.now(timezone.utc).isoformat()
@@ -359,7 +385,15 @@ def _build_from_index_locked(vault: Path) -> dict:
         #     per-paper deletion handles their cleanup.  But newly added keys
         #     need selective hydration so their history isn't lost.
         valid_keys = {e["zotero_key"] for e in items if e.get("zotero_key")}
-        conn.execute("DELETE FROM paper_events WHERE event_type = 'correction_note';")
+        if keys is None:
+            conn.execute("DELETE FROM paper_events WHERE event_type = 'correction_note';")
+        elif valid_keys:
+            placeholders = ",".join("?" for _ in valid_keys)
+            conn.execute(
+                "DELETE FROM paper_events WHERE event_type = 'correction_note' "
+                f"AND paper_id IN ({placeholders});",
+                tuple(sorted(valid_keys)),
+            )
         correction_result = _import_correction_log(conn, vault, valid_keys)
         _hydrate_reading_log_for_keys(conn, vault, diff["added"])
         # 4d. OCR unit rebuilds (per-paper hash comparison).
@@ -393,7 +427,9 @@ def _build_from_index_locked(vault: Path) -> dict:
             "hash_match": False,
             "changed": list(diff["changed"]),
             "added": list(diff["added"]),
-            "deleted": list(diff["deleted"]),
+            # Scoped builds never delete; the diff would report every
+            # non-requested key as deleted against the filtered item set.
+            "deleted": [] if keys is not None else list(diff["deleted"]),
         }
     except Exception:
         conn.rollback()

--- a/tests/test_action_registry.py
+++ b/tests/test_action_registry.py
@@ -131,10 +131,11 @@ class TestRegistryInvariants:
             assert not hasattr(spec, "argv")
             assert not hasattr(spec, "cmd")
 
-    def test_papers_scope_not_registered_yet(self) -> None:
-        # T2: all-scope only; papers scope lands with T3/T4 seams.
-        for spec in ACTION_REGISTRY.values():
-            assert spec.scope_kinds == ("all",)
+    def test_papers_scope_registration_matches_seams(self) -> None:
+        # T3: memory.build gained papers scope; embed.resume still all-only
+        # until the embed seam lands (T4).
+        assert set(ACTION_REGISTRY["memory.build"].scope_kinds) == {"all", "papers"}
+        assert ACTION_REGISTRY["embed.resume"].scope_kinds == ("all",)
 
 
 # ── runner pipeline ────────────────────────────────────────────────────────
@@ -378,9 +379,16 @@ class TestCliExitCodes:
         assert rc == 2
         assert payload["error"]["code"] == "action.unknown"
 
-    def test_run_scope_invalid_is_exit_2(self, tmp_path: Path) -> None:
+    def test_run_papers_scope_unknown_key_is_exit_2(self, tmp_path: Path) -> None:
+        """T3: memory.build accepts papers scope; unknown keys are an invalid
+        scope (exit 2) rejected by preflight (index must exist first)."""
+        from tests.test_memory_build_scoped import _entry, _make_vault, _write_index
+
+        vault = _make_vault(tmp_path)
+        _write_index(vault, [_entry("A", "Paper A")])
         rc, payload = _run_cli(
-            "--vault", str(tmp_path), "action", "run", "memory.build", "--scope", "papers", "--key", "K1", "--json"
+            "--vault", str(vault), "action", "run", "memory.build",
+            "--scope", "papers", "--key", "ZZZ", "--json",
         )
         assert rc == 2
         assert payload["error"]["code"] == "action.scope_invalid"

--- a/tests/test_memory_build_scoped.py
+++ b/tests/test_memory_build_scoped.py
@@ -1,0 +1,254 @@
+"""T3 — memory build papers-scope seam (#164).
+
+Scope fidelity: affected_keys ⊆ requested_keys; subset semantics under
+partial success; scoped builds never delete and never touch non-requested
+papers' rows (whitelisted operation-global metadata may change).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from paperforge.memory.builder import build_for_keys
+
+from tests.conftest import canonical_test_config
+
+
+# ── Fixture helpers (mirror test_build_incremental_ocr.py) ─────────────────
+
+
+def _make_vault(tmp_path: Path) -> Path:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    canonical_test_config(vault, system_dir="System", resources_dir="03_Resources")
+    (vault / "03_Resources" / "Literature" / "骨科").mkdir(parents=True)
+    (vault / "System" / "PaperForge").mkdir(parents=True)
+    return vault
+
+
+def _write_index(vault: Path, items: list[dict]) -> None:
+    from paperforge.worker.asset_index import atomic_write_index, get_index_path
+
+    idx_path = get_index_path(vault)
+    idx_path.parent.mkdir(parents=True, exist_ok=True)
+    atomic_write_index(idx_path, {"items": items, "generated_at": ""})
+
+
+def _make_ocr_artifacts(vault: Path, key: str, *, hash_content: str = "v1") -> None:
+    ocr_dir = vault / "System" / "PaperForge" / "ocr" / key
+    index_dir = ocr_dir / "index"
+    structure_dir = ocr_dir / "structure"
+    index_dir.mkdir(parents=True, exist_ok=True)
+    structure_dir.mkdir(parents=True, exist_ok=True)
+    tree = {
+        "paper_id": key,
+        "nodes": [
+            {
+                "node_id": "sec:intro",
+                "kind": "section",
+                "title": "Introduction",
+                "level": 1,
+                "section_path": ["Introduction"],
+                "page_span": [1, 2],
+                "own_block_ids": ["p1:b1"],
+                "subtree_block_ids": ["p1:b1"],
+                "children": [],
+            }
+        ],
+    }
+    (index_dir / "structure-tree.json").write_text(json.dumps(tree, ensure_ascii=False), encoding="utf-8")
+    blocks = [
+        {"block_id": "b1", "page": 1, "role": "body_paragraph",
+         "text": f"This is the introduction paragraph for {key}."}
+    ]
+    (structure_dir / "blocks.structured.jsonl").write_text(
+        "\n".join(json.dumps(b, ensure_ascii=False) for b in blocks) + "\n",
+        encoding="utf-8",
+    )
+    (index_dir / "role-index.json").write_text(
+        json.dumps({"figure_captions": [], "table_captions": [], "headings": []}, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    (index_dir / "result-hash.txt").write_text(hash_content, encoding="utf-8")
+
+
+def _entry(key: str, title: str) -> dict:
+    return {"zotero_key": key, "title": title, "domain": "骨科"}
+
+
+def _papers(vault: Path, key: str) -> dict:
+    """Full row snapshot of one paper (all columns, rowid, updated_at)."""
+    from paperforge.memory.db import get_connection, get_memory_db_path
+
+    conn = get_connection(get_memory_db_path(vault))
+    try:
+        row = conn.execute("SELECT * FROM papers WHERE zotero_key = ?", (key,)).fetchone()
+        return dict(row) if row else None
+    finally:
+        conn.close()
+
+
+def _rows(vault: Path, sql: str, key: str) -> list[dict]:
+    from paperforge.memory.db import get_connection, get_memory_db_path
+
+    conn = get_connection(get_memory_db_path(vault))
+    try:
+        return [dict(r) for r in conn.execute(sql, (key,)).fetchall()]
+    finally:
+        conn.close()
+
+
+def _snapshot(vault: Path, keys: tuple[str, ...]) -> dict[str, object]:
+    """Byte-identity snapshot of everything owned by the given papers."""
+    out: dict[str, object] = {}
+    for key in keys:
+        out[f"papers:{key}"] = _papers(vault, key)
+        out[f"body:{key}"] = _rows(vault, "SELECT * FROM body_units WHERE paper_id = ? ORDER BY unit_id", key)
+        out[f"obj:{key}"] = _rows(vault, "SELECT * FROM object_units WHERE paper_id = ? ORDER BY unit_id", key)
+        out[f"alias:{key}"] = _rows(vault, "SELECT * FROM paper_aliases WHERE paper_id = ? ORDER BY alias", key)
+        out[f"asset:{key}"] = _rows(vault, "SELECT * FROM paper_assets WHERE paper_id = ? ORDER BY asset_type", key)
+        out[f"manifest:{key}"] = _rows(vault, "SELECT value FROM meta WHERE key = ?", f"manifest:{key}")
+        out[f"state:{key}"] = _rows(vault, "SELECT value FROM meta WHERE key = ?", f"paper_state_hash:{key}")
+    return out
+
+
+def _three_paper_vault(tmp_path: Path) -> Path:
+    vault = _make_vault(tmp_path)
+    for key in ("A", "B", "C"):
+        _make_ocr_artifacts(vault, key)
+    _write_index(vault, [_entry("A", "Paper A"), _entry("B", "Paper B"), _entry("C", "Paper C")])
+    build_for_keys(vault, None)  # full build baseline
+    return vault
+
+
+# ── subset semantics (the acceptance test) ─────────────────────────────────
+
+class TestSubsetSemantics:
+    def test_scoped_build_touches_only_requested_keys(self, tmp_path: Path) -> None:
+        vault = _three_paper_vault(tmp_path)
+        before = _snapshot(vault, ("B", "C"))
+
+        # Change ONLY A: title + OCR artifacts.
+        _write_index(vault, [
+            _entry("A", "Paper A v2"), _entry("B", "Paper B"), _entry("C", "Paper C"),
+        ])
+        _make_ocr_artifacts(vault, "A", hash_content="v2")
+
+        result = build_for_keys(vault, ["A", "B"])
+
+        assert set(result["changed"]) == {"A"}
+        assert result["deleted"] == []
+        after = _snapshot(vault, ("B", "C"))
+        # B and C are byte-identical (rowid/updated_at included).
+        assert after == before, "non-requested papers changed"
+        # A actually rebuilt.
+        assert _papers(vault, "A")["title"] == "Paper A v2"
+
+    def test_scoped_build_with_unchanged_keys_is_noop(self, tmp_path: Path) -> None:
+        vault = _three_paper_vault(tmp_path)
+        before = _snapshot(vault, ("A", "B", "C"))
+        result = build_for_keys(vault, ["A"])
+        assert set(result.get("changed", [])) <= {"A"}
+        assert result.get("deleted", []) == []
+        assert _snapshot(vault, ("A", "B", "C")) == before
+
+    def test_scoped_build_never_deletes_non_requested(self, tmp_path: Path) -> None:
+        """Request [A] while B/C exist in the DB — the deletion gate holds."""
+        vault = _three_paper_vault(tmp_path)
+        before_b = _snapshot(vault, ("B",))
+        # Drop B from the index entirely; request only A.
+        _write_index(vault, [_entry("A", "Paper A"), _entry("C", "Paper C")])
+        result = build_for_keys(vault, ["A"])
+        assert result["deleted"] == []
+        assert _snapshot(vault, ("B",)) == before_b, "scoped build deleted a non-requested paper"
+
+    def test_scoped_artifacts_gone_clears_requested_only(self, tmp_path: Path) -> None:
+        vault = _three_paper_vault(tmp_path)
+        before = _snapshot(vault, ("B", "C"))
+        # Delete A's OCR artifacts; scoped build must clear A's units but
+        # leave B/C untouched.
+        import shutil
+
+        shutil.rmtree(vault / "System" / "PaperForge" / "ocr" / "A")
+        result = build_for_keys(vault, ["A"])
+        assert _rows(vault, "SELECT COUNT(*) AS n FROM body_units WHERE paper_id = ?", "A") == [{"n": 0}]
+        assert _snapshot(vault, ("B", "C")) == before
+
+
+# ── canonical-keys validation ──────────────────────────────────────────────
+
+class TestKeyValidation:
+    def test_unknown_key_raises(self, tmp_path: Path) -> None:
+        vault = _three_paper_vault(tmp_path)
+        before = _snapshot(vault, ("A", "B", "C"))
+        with pytest.raises(ValueError, match="ZZZ"):
+            build_for_keys(vault, ["A", "ZZZ"])
+        # DB untouched on validation failure.
+        assert _snapshot(vault, ("A", "B", "C")) == before
+
+    def test_full_build_unchanged_behavior(self, tmp_path: Path) -> None:
+        vault = _three_paper_vault(tmp_path)
+        result = build_for_keys(vault, None)
+        assert result["hash_match"] is True  # second full build fast-paths
+
+
+# ── action registry / CLI wiring ───────────────────────────────────────────
+
+def _run_cli(*argv: str) -> tuple[int, dict]:
+    import io as _io
+    import sys as _sys
+
+    from paperforge.cli import main
+
+    old_out = _sys.stdout
+    buf = _io.StringIO()
+    _sys.stdout = buf
+    try:
+        rc = main(list(argv))
+    finally:
+        _sys.stdout = old_out
+    return rc, json.loads(buf.getvalue())
+
+
+class TestRegistryAndCli:
+    def test_action_unknown_key_is_exit_2(self, tmp_path: Path) -> None:
+        vault = _three_paper_vault(tmp_path)
+        rc, payload = _run_cli(
+            "--vault", str(vault), "action", "run", "memory.build",
+            "--scope", "papers", "--key", "ZZZ", "--json",
+        )
+        assert rc == 2
+        assert payload["error"]["code"] == "action.scope_invalid"
+
+    def test_action_papers_scope_runs(self, tmp_path: Path) -> None:
+        vault = _three_paper_vault(tmp_path)
+        _make_ocr_artifacts(vault, "A", hash_content="v3")
+        _write_index(vault, [
+            _entry("A", "Paper A v3"), _entry("B", "Paper B"), _entry("C", "Paper C"),
+        ])
+        rc, payload = _run_cli(
+            "--vault", str(vault), "action", "run", "memory.build",
+            "--scope", "papers", "--key", "A", "--json",
+        )
+        assert rc == 0, payload
+        assert payload["data"]["changed"] == ["A"]
+        # scoped follow-up intent carries the same keys
+        assert payload["next_actions"][0]["scope"] == {"kind": "papers", "keys": ["A"]}
+
+    def test_action_papers_scope_zero_keys_is_exit_2(self, tmp_path: Path) -> None:
+        vault = _three_paper_vault(tmp_path)
+        rc, payload = _run_cli(
+            "--vault", str(vault), "action", "run", "memory.build",
+            "--scope", "papers", "--json",
+        )
+        assert rc == 2
+        assert payload["error"]["code"] == "action.scope_invalid"
+
+    def test_memory_cli_unknown_key_is_exit_2(self, tmp_path: Path) -> None:
+        vault = _three_paper_vault(tmp_path)
+        rc, payload = _run_cli("--vault", str(vault), "memory", "build", "--key", "ZZZ", "--json")
+        assert rc == 2
+        assert payload["error"]["code"] == "action.scope_invalid"


### PR DESCRIPTION
## T3 — Memory build papers-scope seam (#164, #145 §4.2)

Scope-faithful memory seam + memory.build papers scope. Whole-slice revert unit.

### What landed (`38edcfd0`)
- `build_for_keys(vault, keys)`: keys=None → unchanged whole-library build; keys given → validated against canonical formal-library keys (unknown → ValueError → exit 2), items filtered **after** the fresh/destructive full-rebuild decision, deletion loop gated (`if keys is None` — scoped builds never delete), correction-event rewrite restricted to requested keys, `deleted` reported [] when scoped
- canonical hash computed over FULL items and published LAST — a scoped build never publishes a subset hash (fast-path contract intact)
- `memory.build` registers **papers** scope; preflight rejects unknown keys with exit 2 (`action.scope_invalid`); handler passes keys into the seam and emits `embed.resume` with `PapersScope(keys)` (T6 wires the chain)
- memory CLI: `--key` repeatable; unknown key → exit 2

### Tests (10 new)
| Test | Guards |
|---|---|
| `test_scoped_build_touches_only_requested_keys` | A/B/C fixture, request [A,B], only A changed → B/C snapshots byte-identical (rowid/updated_at/units/objects/aliases/assets/manifests/state) |
| `test_scoped_build_with_unchanged_keys_is_noop` | hash-match fast path; nothing touched |
| `test_scoped_build_never_deletes_non_requested` | deletion gate: B survives a scoped request even when dropped from the index |
| `test_scoped_artifacts_gone_clears_requested_only` | A's units cleared, B/C untouched |
| `test_unknown_key_raises` | DB untouched on validation failure |
| registry/CLI | unknown key → exit 2 (action + memory CLI); papers-scope run → rc0 + scoped follow-up intent; zero keys → exit 2 |

Registry invariant tests updated: memory.build `(all, papers)`, embed.resume stays `(all,)` until the embed seam (T4).

### Evidence
- Python **3031 passed / 296 skipped**; ruff clean; existing memory/build suites pass unmodified

Closes: #164. Part of: #135.