### PR TITLE
T3 corrective: early key validation, no scoped substrate init, global hash gating (#164)

### DIFF
--- a/paperforge/actions/registry.py
+++ b/paperforge/actions/registry.py
@@ -76,6 +76,19 @@ def _memory_build_handler(ctx: ActionContext, request: ActionRequest) -> PFResul
 
     try:
         counts = build_for_keys(ctx.vault, keys)
+        if counts.get("global_rebuild_required"):
+            # #164 corrective: a scoped request must never initialize the
+            # global substrate — the schema needs a full memory.build(all).
+            return PFResult(
+                ok=False,
+                command="action run",
+                version=PF_VERSION,
+                error=PFError(
+                    code=ErrorCode.ACTION_UNAVAILABLE,
+                    message="memory schema requires a full rebuild — "
+                    "run `paperforge action run memory.build` (all scope) first",
+                ),
+            )
     except FileNotFoundError as exc:
         return PFResult(
             ok=False,

--- a/paperforge/commands/memory.py
+++ b/paperforge/commands/memory.py
@@ -166,6 +166,22 @@ def run(args: argparse.Namespace) -> int:
             from paperforge.memory.builder import build_for_keys
 
             counts = build_for_keys(vault, keys)
+            if counts.get("global_rebuild_required"):
+                result = PFResult(
+                    ok=False,
+                    command="memory build",
+                    version=PF_VERSION,
+                    error=PFError(
+                        code=ErrorCode.ACTION_UNAVAILABLE,
+                        message="memory schema requires a full rebuild — "
+                        "run `paperforge memory build` (all keys) first",
+                    ),
+                )
+                if args.json:
+                    print(result.to_json())
+                else:
+                    print(result.error.message, file=sys.stderr)
+                return 1
             result = PFResult(
                 ok=True,
                 command="memory build",

--- a/paperforge/memory/builder.py
+++ b/paperforge/memory/builder.py
@@ -312,6 +312,16 @@ def _build_from_index_locked(vault: Path, keys: list[str] | None = None) -> dict
         else ""
     )
 
+    # ── 0. Scoped request: validate keys against the canonical index BEFORE
+    #      any writable DB access — an unknown key is an invalid scope with
+    #      ZERO side effects (exit 2 upstream), even on a fresh DB. ──
+    if keys is not None:
+        canonical_keys = {e["zotero_key"] for e in items if e.get("zotero_key")}
+        unknown = sorted(set(keys) - canonical_keys)
+        if unknown:
+            raise ValueError(f"unknown paper keys: {unknown}")
+        items = [e for e in items if e.get("zotero_key") in set(keys)]
+
     db_path = get_memory_db_path(vault)
     conn = get_connection(db_path, read_only=False)
     try:
@@ -326,19 +336,22 @@ def _build_from_index_locked(vault: Path, keys: list[str] | None = None) -> dict
 
         # ── 2. Fresh or destructive → full rebuild ────────────────────────
         if migration_action in ("fresh", "destructive"):
+            if keys is not None:
+                # A scoped request must never initialize/migrate the global
+                # substrate: every paper would be materialized (violating
+                # affected ⊆ requested).  #159 global-first: the substrate
+                # needs a memory.build(all) intent instead.
+                conn.close()
+                return {
+                    "global_rebuild_required": True,
+                    "reason": migration_action,
+                    "db_path": str(db_path),
+                    "requested_keys": list(keys),
+                }
             result = _full_rebuild(conn, vault, items, canonical_hash, generated_at, ocr_root)
             conn.commit()
             conn.close()
             return result
-
-        # ── 2.5 Scoped build: validate keys against the canonical index and
-        #      filter — everything below schedules over the filtered set ──
-        if keys is not None:
-            canonical_keys = {e["zotero_key"] for e in items if e.get("zotero_key")}
-            unknown = sorted(set(keys) - canonical_keys)
-            if unknown:
-                raise ValueError(f"unknown paper keys: {unknown}")
-            items = [e for e in items if e.get("zotero_key") in set(keys)]
 
         # ── 3. Global hash unchanged + no schema change → fast path ──────
         if migration_action == "none" and canonical_hash and db_path.exists():
@@ -400,16 +413,19 @@ def _build_from_index_locked(vault: Path, keys: list[str] | None = None) -> dict
         #     Always run — function internally handles missing OCR artifacts.
         _incremental_units_only(conn, items, ocr_root, vault=vault)
 
-        # 4e. Advance canonical hash LAST — if anything fails before this,
-        #     the next run re-diffs and retries
-        conn.execute(
-            "INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)",
-            ("canonical_index_hash", canonical_hash),
-        )
-        conn.execute(
-            "INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)",
-            ("canonical_index_generated_at", generated_at),
-        )
+        # 4e. Advance the global canonical hash LAST — ALL-SCOPE builds only.
+        #     A scoped build must never publish the full-index hash: it would
+        #     let the next full build take the fast path and permanently mask
+        #     non-requested papers' stale metadata.
+        if keys is None:
+            conn.execute(
+                "INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)",
+                ("canonical_index_hash", canonical_hash),
+            )
+            conn.execute(
+                "INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)",
+                ("canonical_index_generated_at", generated_at),
+            )
 
         logger.info(
             "Index built: %d changed, %d deleted, %d corrections (orphans: %d)",

--- a/tests/test_memory_build_scoped.py
+++ b/tests/test_memory_build_scoped.py
@@ -213,6 +213,99 @@ def _run_cli(*argv: str) -> tuple[int, dict]:
     return rc, json.loads(buf.getvalue())
 
 
+class TestGlobalFreshness:
+    """#164 corrective: the global canonical_index_hash is a correctness
+    marker — only all-scope builds advance it; a scoped publish must not
+    mask non-requested papers' stale metadata."""
+
+    def _cached_hash(self, vault: Path):
+        from paperforge.memory.db import get_connection, get_memory_db_path
+
+        conn = get_connection(get_memory_db_path(vault))
+        try:
+            row = conn.execute(
+                "SELECT value FROM meta WHERE key='canonical_index_hash'"
+            ).fetchone()
+            return row[0] if row else None
+        finally:
+            conn.close()
+
+    def test_scoped_build_does_not_advance_global_hash(self, tmp_path: Path) -> None:
+        vault = _three_paper_vault(tmp_path)
+        before = self._cached_hash(vault)
+        assert before
+
+        # A + B change in the canonical index; scope only A.
+        _write_index(vault, [
+            _entry("A", "Paper A v2"), _entry("B", "Paper B v2"), _entry("C", "Paper C"),
+        ])
+        _make_ocr_artifacts(vault, "A", hash_content="v2")
+        result = build_for_keys(vault, ["A"])
+        assert set(result["changed"]) == {"A"}
+        # The global freshness marker is NOT advanced by the scoped build.
+        assert self._cached_hash(vault) == before
+
+    def test_full_build_after_scoped_still_rebuilds_stale_paper(self, tmp_path: Path) -> None:
+        """The regression: A+B changed, scope A, then full build — B must be
+        rebuilt (the scoped publish must not have fast-pathed it away)."""
+        vault = _three_paper_vault(tmp_path)
+        _write_index(vault, [
+            _entry("A", "Paper A v2"), _entry("B", "Paper B v2"), _entry("C", "Paper C"),
+        ])
+        _make_ocr_artifacts(vault, "A", hash_content="v2")
+        build_for_keys(vault, ["A"])
+
+        full = build_for_keys(vault, None)
+        assert full["hash_match"] is False
+        assert "B" in set(full["changed"]), "full build must still see B's change"
+        assert _papers(vault, "B")["title"] == "Paper B v2"
+
+    def test_full_build_still_fast_paths_after_clean_full_build(self, tmp_path: Path) -> None:
+        vault = _three_paper_vault(tmp_path)
+        full = build_for_keys(vault, None)
+        assert full["hash_match"] is True
+
+
+class TestScopedOnFreshDatabase:
+    """#164 corrective: a scoped request on a fresh/destructive DB must not
+    materialize the whole library — it reports global_rebuild_required."""
+
+    def test_scoped_fresh_db_returns_global_rebuild_required(self, tmp_path: Path) -> None:
+        vault = _make_vault(tmp_path)
+        for key in ("A", "B", "C"):
+            _make_ocr_artifacts(vault, key)
+        _write_index(vault, [_entry("A", "A"), _entry("B", "B"), _entry("C", "C")])
+        result = build_for_keys(vault, ["A"])
+        assert result["global_rebuild_required"] is True
+        # No paper rows were materialized by the scoped request.
+        assert _papers(vault, "B") is None
+        assert _papers(vault, "A") is None
+
+    def test_unknown_key_on_fresh_db_has_zero_side_effects(self, tmp_path: Path) -> None:
+        vault = _make_vault(tmp_path)
+        _write_index(vault, [_entry("A", "A")])
+        from paperforge.memory.db import get_memory_db_path
+
+        db = get_memory_db_path(vault)
+        before = db.exists()
+        with pytest.raises(ValueError, match="ZZZ"):
+            build_for_keys(vault, ["ZZZ"])
+        # Validation happened before any writable DB access.
+        assert db.exists() == before
+
+    def test_scoped_action_fresh_db_is_structured_unavailable(self, tmp_path: Path) -> None:
+        vault = _make_vault(tmp_path)
+        for key in ("A", "B"):
+            _make_ocr_artifacts(vault, key)
+        _write_index(vault, [_entry("A", "A"), _entry("B", "B")])
+        rc, payload = _run_cli(
+            "--vault", str(vault), "action", "run", "memory.build",
+            "--scope", "papers", "--key", "A", "--json",
+        )
+        assert rc == 1
+        assert payload["error"]["code"] == "action.unavailable"
+
+
 class TestRegistryAndCli:
     def test_action_unknown_key_is_exit_2(self, tmp_path: Path) -> None:
         vault = _three_paper_vault(tmp_path)


### PR DESCRIPTION
## T3 corrective (review of #184)

### P0-1 — validation timing + scoped substrate init
Canonical-key validation now runs BEFORE any writable DB access — unknown keys have zero side effects even on a fresh DB (the old order let the fresh/destructive full-rebuild path bypass validation). A papers-scoped request on a fresh/destructive DB no longer materializes the whole library: it returns `global_rebuild_required` (registry handler / memory CLI map it to structured `action.unavailable`) — matching #159 global-first (schema substrate needs a `memory.build(all)` intent).

### P0-2 — global canonical_index_hash gating
`canonical_index_hash` is a correctness/freshness marker; only ALL-scope builds advance it. A scoped publish previously wrote the full-index hash, letting the next full build take the fast path and permanently mask non-requested papers' stale metadata.

### Tests (5 new)
- scoped build does not advance the global hash
- full build after scoped still rebuilds the stale paper (the masking regression: A+B changed, scope A, full build → B rebuilt)
- scoped fresh DB → global_rebuild_required, zero materialized rows
- unknown key on fresh DB → zero side effects (DB untouched)
- scoped action on fresh DB → structured unavailable

### Evidence
- Python **3047 passed / 296 skipped**; ruff clean

Closes: #164.