### PR TITLE
T4 corrective: lineage paper_ids filter no-op + resume downgrade routing (#165)

### DIFF
--- a/paperforge/actions/registry.py
+++ b/paperforge/actions/registry.py
@@ -76,6 +76,19 @@ def _memory_build_handler(ctx: ActionContext, request: ActionRequest) -> PFResul
 
     try:
         counts = build_for_keys(ctx.vault, keys)
+        if counts.get("global_rebuild_required"):
+            # #164 corrective: a scoped request must never initialize the
+            # global substrate — the schema needs a full memory.build(all).
+            return PFResult(
+                ok=False,
+                command="action run",
+                version=PF_VERSION,
+                error=PFError(
+                    code=ErrorCode.ACTION_UNAVAILABLE,
+                    message="memory schema requires a full rebuild — "
+                    "run `paperforge action run memory.build` (all scope) first",
+                ),
+            )
     except FileNotFoundError as exc:
         return PFResult(
             ok=False,

--- a/paperforge/commands/embed.py
+++ b/paperforge/commands/embed.py
@@ -442,13 +442,20 @@ def run_build(
                         print(msg)
                     resume = False
 
+        # #165 corrective: `requested_resume` is what the caller asked for;
+        # the gates above downgrade `resume` (effective) — a downgrade means
+        # a full rebuild is required, which must route through shadow.
+        # The old `_force_rebuild = force or (resume is False and resume)`
+        # was always False on the second clause (True and False) — the
+        # resume-reset path silently degraded to in-place.
+        requested_resume = resume
         # P0-2: full rebuild must never honor resume — the candidate's
         # vector tables are cleared, so a hash-skip would publish a DB
         # missing those papers' vectors.  Force wins over resume at both the
         # CLI (mutually exclusive group) and programmatic call sites.
         if force:
             resume = False
-        _force_rebuild = force or (resume is False and resume)
+        _force_rebuild = force or (requested_resume and not resume)
         # D5: full rebuilds (force / model change / resume reset) use shadow target.
         # P1: embedding identity is (provider endpoint, model) — a config
         # switch of EITHER must route through shadow.  A plain `embed build`

--- a/paperforge/commands/memory.py
+++ b/paperforge/commands/memory.py
@@ -166,6 +166,22 @@ def run(args: argparse.Namespace) -> int:
             from paperforge.memory.builder import build_for_keys
 
             counts = build_for_keys(vault, keys)
+            if counts.get("global_rebuild_required"):
+                result = PFResult(
+                    ok=False,
+                    command="memory build",
+                    version=PF_VERSION,
+                    error=PFError(
+                        code=ErrorCode.ACTION_UNAVAILABLE,
+                        message="memory schema requires a full rebuild — "
+                        "run `paperforge memory build` (all keys) first",
+                    ),
+                )
+                if args.json:
+                    print(result.to_json())
+                else:
+                    print(result.error.message, file=sys.stderr)
+                return 1
             result = PFResult(
                 ok=True,
                 command="memory build",

--- a/paperforge/lineage.py
+++ b/paperforge/lineage.py
@@ -165,11 +165,13 @@ def write_vector_lineage(
     )
     stamp = updated_at or datetime.now(timezone.utc).isoformat()
 
-    paper_ids = _papers_with_vectors(conn)
+    # #165 corrective: the parameter must not be shadowed — the filter is
+    # applied to the eligible set derived from the connection.
+    eligible_paper_ids = _papers_with_vectors(conn)
     if paper_ids is not None:
-        paper_ids = [p for p in paper_ids if p in paper_ids]
+        eligible_paper_ids = [p for p in eligible_paper_ids if p in paper_ids]
     written = 0
-    for paper_id in paper_ids:
+    for paper_id in eligible_paper_ids:
         row = conn.execute(
             "SELECT value FROM meta WHERE key = ?", (f"manifest:{paper_id}",)
         ).fetchone()

--- a/paperforge/memory/builder.py
+++ b/paperforge/memory/builder.py
@@ -312,6 +312,16 @@ def _build_from_index_locked(vault: Path, keys: list[str] | None = None) -> dict
         else ""
     )
 
+    # ── 0. Scoped request: validate keys against the canonical index BEFORE
+    #      any writable DB access — an unknown key is an invalid scope with
+    #      ZERO side effects (exit 2 upstream), even on a fresh DB. ──
+    if keys is not None:
+        canonical_keys = {e["zotero_key"] for e in items if e.get("zotero_key")}
+        unknown = sorted(set(keys) - canonical_keys)
+        if unknown:
+            raise ValueError(f"unknown paper keys: {unknown}")
+        items = [e for e in items if e.get("zotero_key") in set(keys)]
+
     db_path = get_memory_db_path(vault)
     conn = get_connection(db_path, read_only=False)
     try:
@@ -326,19 +336,22 @@ def _build_from_index_locked(vault: Path, keys: list[str] | None = None) -> dict
 
         # ── 2. Fresh or destructive → full rebuild ────────────────────────
         if migration_action in ("fresh", "destructive"):
+            if keys is not None:
+                # A scoped request must never initialize/migrate the global
+                # substrate: every paper would be materialized (violating
+                # affected ⊆ requested).  #159 global-first: the substrate
+                # needs a memory.build(all) intent instead.
+                conn.close()
+                return {
+                    "global_rebuild_required": True,
+                    "reason": migration_action,
+                    "db_path": str(db_path),
+                    "requested_keys": list(keys),
+                }
             result = _full_rebuild(conn, vault, items, canonical_hash, generated_at, ocr_root)
             conn.commit()
             conn.close()
             return result
-
-        # ── 2.5 Scoped build: validate keys against the canonical index and
-        #      filter — everything below schedules over the filtered set ──
-        if keys is not None:
-            canonical_keys = {e["zotero_key"] for e in items if e.get("zotero_key")}
-            unknown = sorted(set(keys) - canonical_keys)
-            if unknown:
-                raise ValueError(f"unknown paper keys: {unknown}")
-            items = [e for e in items if e.get("zotero_key") in set(keys)]
 
         # ── 3. Global hash unchanged + no schema change → fast path ──────
         if migration_action == "none" and canonical_hash and db_path.exists():
@@ -400,16 +413,19 @@ def _build_from_index_locked(vault: Path, keys: list[str] | None = None) -> dict
         #     Always run — function internally handles missing OCR artifacts.
         _incremental_units_only(conn, items, ocr_root, vault=vault)
 
-        # 4e. Advance canonical hash LAST — if anything fails before this,
-        #     the next run re-diffs and retries
-        conn.execute(
-            "INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)",
-            ("canonical_index_hash", canonical_hash),
-        )
-        conn.execute(
-            "INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)",
-            ("canonical_index_generated_at", generated_at),
-        )
+        # 4e. Advance the global canonical hash LAST — ALL-SCOPE builds only.
+        #     A scoped build must never publish the full-index hash: it would
+        #     let the next full build take the fast path and permanently mask
+        #     non-requested papers' stale metadata.
+        if keys is None:
+            conn.execute(
+                "INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)",
+                ("canonical_index_hash", canonical_hash),
+            )
+            conn.execute(
+                "INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)",
+                ("canonical_index_generated_at", generated_at),
+            )
 
         logger.info(
             "Index built: %d changed, %d deleted, %d corrections (orphans: %d)",

--- a/tests/test_embed_scoped.py
+++ b/tests/test_embed_scoped.py
@@ -223,7 +223,8 @@ class TestLineagePreservation:
     def test_resume_skipped_papers_keep_lineage_rows_byte_identical(self, tmp_path: Path) -> None:
         canonical_test_config(tmp_path, system_dir="System")
         _seed_resume_db(tmp_path, ("A", "B", "C"))
-        _store_manifest(tmp_path, "A")
+        for key in ("A", "B", "C"):
+            _store_manifest(tmp_path, key)
         _store_lineage_row(tmp_path, "B", "2026-01-01T00:00:00+00:00")
         _store_lineage_row(tmp_path, "C", "2026-01-01T00:00:00+00:00")
         before_b = _lineage_rows(tmp_path, "B")
@@ -269,6 +270,138 @@ class TestLineagePreservation:
 
 
 # ── RecordingEmbeddingProvider (test-only, no product seam) ────────────────
+
+    def test_paper_ids_filter_restricts_lineage_writes(self, tmp_path: Path) -> None:
+        """#165 corrective: write_vector_lineage(paper_ids=...) rewrites ONLY
+        the listed papers — even when B/C carry valid manifests (the old
+        variable-shadowing bug made this filter a no-op)."""
+        from paperforge.lineage import write_vector_lineage
+        from paperforge.memory.db import get_memory_db_path
+
+        canonical_test_config(tmp_path, system_dir="System")
+        _seed_resume_db(tmp_path, ("A", "B", "C"))
+        for key in ("A", "B", "C"):
+            _store_manifest(tmp_path, key)
+        _store_lineage_row(tmp_path, "A", "2026-01-01T00:00:00+00:00")
+        _store_lineage_row(tmp_path, "B", "2026-01-01T00:00:00+00:00")
+        _store_lineage_row(tmp_path, "C", "2026-01-01T00:00:00+00:00")
+        before_b = _lineage_rows(tmp_path, "B")
+        before_c = _lineage_rows(tmp_path, "C")
+
+        conn = sqlite3.connect(str(get_memory_db_path(tmp_path)))
+        try:
+            n = write_vector_lineage(
+                conn, tmp_path,
+                endpoint="https://api.openai.com/v1",
+                model="m",
+                dimension=3,
+                paper_ids={"A"},
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        assert n == 1
+        # A's row was rewritten (fresh updated_at), B/C byte-identical.
+        assert _lineage_rows(tmp_path, "A")[0][5] != "2026-01-01T00:00:00+00:00"
+        assert _lineage_rows(tmp_path, "B") == before_b
+        assert _lineage_rows(tmp_path, "C") == before_c
+
+
+class TestResumeResetRouting:
+    """#165 corrective: a resume request downgraded by a gate (stale
+    recovery / no rows / model change) must route through shadow — the
+    extraction must be behavior-preserving; scoped requests fail before any
+    paper mutation."""
+
+    def _stale_build_state(self, tmp_path: Path) -> None:
+        from paperforge.memory.db import get_memory_db_path
+
+        conn = sqlite3.connect(str(get_memory_db_path(tmp_path)))
+        try:
+            conn.execute(
+                "INSERT OR REPLACE INTO build_state (key, value) VALUES ('status', ?)",
+                ('"running"',),
+            )
+            conn.execute(
+                "INSERT OR REPLACE INTO build_state (key, value) VALUES ('pid', '99999999')"
+            )
+            conn.execute(
+                "INSERT OR REPLACE INTO build_state (key, value) VALUES ('vector_identity_version', '1')"
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    def test_resume_reset_routes_shadow_unscoped(self, tmp_path: Path) -> None:
+        """resume=True + stale running recovery downgrades resume; the
+        unscoped build must route through the shadow rebuild path."""
+        canonical_test_config(tmp_path, system_dir="System")
+        _seed_resume_db(tmp_path, ("A",))
+        self._stale_build_state(tmp_path)
+
+        from unittest.mock import patch
+
+        shadow_prepared: list[str] = []
+
+        def encode(vault, job):
+            # Shadow vec tables are created at the model-detected dimension.
+            from tests.test_pr9c_streaming_embed import EncodedPayload, PaperEncodedBundle
+
+            bundle = _make_bundle(job.paper_id, n_chunks=1)
+            return PaperEncodedBundle(
+                paper_id=bundle.paper_id,
+                payloads=[
+                    EncodedPayload(
+                        collection_name=p.collection_name,
+                        texts=p.texts,
+                        ids=p.ids,
+                        metadatas=p.metadatas,
+                        embeddings=[[0.1] * 1536 for _ in p.embeddings],
+                    )
+                    for p in bundle.payloads
+                ],
+                chunk_count=bundle.chunk_count,
+            )
+
+        with patch("paperforge.commands.embed.encode_paper_job", side_effect=encode), \
+             patch("paperforge.commands.embed.prepare_payloads_for_entry",
+                   side_effect=lambda vault, key, *a, **k: _payloads_for(key)), \
+             patch("paperforge.commands.embed.ensure_vec_tables", return_value=1536), \
+             patch("paperforge.commands.embed.delete_paper_vectors"), \
+             patch("paperforge.commands.embed.write_encoded_payload"), \
+             patch("paperforge.commands.embed._pid_alive", return_value=False):
+            from paperforge.embedding.build_target import ShadowBuild
+            orig_prepare = ShadowBuild.prepare
+
+            def spy_prepare(self):
+                shadow_prepared.append("prepare")
+                return orig_prepare(self)
+
+            ShadowBuild.prepare = spy_prepare
+            try:
+                rc = run_build(tmp_path, _papers(("A",)), keys=None, resume=True)
+            finally:
+                ShadowBuild.prepare = orig_prepare
+
+        assert rc == 0
+        assert shadow_prepared == ["prepare"], "resume-reset must route through shadow"
+
+    def test_scoped_resume_reset_fails_before_mutation(self, tmp_path: Path) -> None:
+        """Same downgrade with a papers-scoped request: fail fast before
+        any paper mutation (no encodes)."""
+        canonical_test_config(tmp_path, system_dir="System")
+        _seed_resume_db(tmp_path, ("A",))
+        self._stale_build_state(tmp_path)
+
+        from unittest.mock import patch
+
+        with patch("paperforge.commands.embed.encode_paper_job") as enc, \
+             patch("paperforge.commands.embed._pid_alive", return_value=False):
+            rc = run_build(tmp_path, _papers(("A",)), keys=["A"], resume=True)
+        assert rc == 1
+        enc.assert_not_called()
+
 
 class TestRecordingEmbeddingProvider:
     def test_provider_seam_records_requested_keys_only(self, tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_memory_build_scoped.py
+++ b/tests/test_memory_build_scoped.py
@@ -213,6 +213,99 @@ def _run_cli(*argv: str) -> tuple[int, dict]:
     return rc, json.loads(buf.getvalue())
 
 
+class TestGlobalFreshness:
+    """#164 corrective: the global canonical_index_hash is a correctness
+    marker — only all-scope builds advance it; a scoped publish must not
+    mask non-requested papers' stale metadata."""
+
+    def _cached_hash(self, vault: Path):
+        from paperforge.memory.db import get_connection, get_memory_db_path
+
+        conn = get_connection(get_memory_db_path(vault))
+        try:
+            row = conn.execute(
+                "SELECT value FROM meta WHERE key='canonical_index_hash'"
+            ).fetchone()
+            return row[0] if row else None
+        finally:
+            conn.close()
+
+    def test_scoped_build_does_not_advance_global_hash(self, tmp_path: Path) -> None:
+        vault = _three_paper_vault(tmp_path)
+        before = self._cached_hash(vault)
+        assert before
+
+        # A + B change in the canonical index; scope only A.
+        _write_index(vault, [
+            _entry("A", "Paper A v2"), _entry("B", "Paper B v2"), _entry("C", "Paper C"),
+        ])
+        _make_ocr_artifacts(vault, "A", hash_content="v2")
+        result = build_for_keys(vault, ["A"])
+        assert set(result["changed"]) == {"A"}
+        # The global freshness marker is NOT advanced by the scoped build.
+        assert self._cached_hash(vault) == before
+
+    def test_full_build_after_scoped_still_rebuilds_stale_paper(self, tmp_path: Path) -> None:
+        """The regression: A+B changed, scope A, then full build — B must be
+        rebuilt (the scoped publish must not have fast-pathed it away)."""
+        vault = _three_paper_vault(tmp_path)
+        _write_index(vault, [
+            _entry("A", "Paper A v2"), _entry("B", "Paper B v2"), _entry("C", "Paper C"),
+        ])
+        _make_ocr_artifacts(vault, "A", hash_content="v2")
+        build_for_keys(vault, ["A"])
+
+        full = build_for_keys(vault, None)
+        assert full["hash_match"] is False
+        assert "B" in set(full["changed"]), "full build must still see B's change"
+        assert _papers(vault, "B")["title"] == "Paper B v2"
+
+    def test_full_build_still_fast_paths_after_clean_full_build(self, tmp_path: Path) -> None:
+        vault = _three_paper_vault(tmp_path)
+        full = build_for_keys(vault, None)
+        assert full["hash_match"] is True
+
+
+class TestScopedOnFreshDatabase:
+    """#164 corrective: a scoped request on a fresh/destructive DB must not
+    materialize the whole library — it reports global_rebuild_required."""
+
+    def test_scoped_fresh_db_returns_global_rebuild_required(self, tmp_path: Path) -> None:
+        vault = _make_vault(tmp_path)
+        for key in ("A", "B", "C"):
+            _make_ocr_artifacts(vault, key)
+        _write_index(vault, [_entry("A", "A"), _entry("B", "B"), _entry("C", "C")])
+        result = build_for_keys(vault, ["A"])
+        assert result["global_rebuild_required"] is True
+        # No paper rows were materialized by the scoped request.
+        assert _papers(vault, "B") is None
+        assert _papers(vault, "A") is None
+
+    def test_unknown_key_on_fresh_db_has_zero_side_effects(self, tmp_path: Path) -> None:
+        vault = _make_vault(tmp_path)
+        _write_index(vault, [_entry("A", "A")])
+        from paperforge.memory.db import get_memory_db_path
+
+        db = get_memory_db_path(vault)
+        before = db.exists()
+        with pytest.raises(ValueError, match="ZZZ"):
+            build_for_keys(vault, ["ZZZ"])
+        # Validation happened before any writable DB access.
+        assert db.exists() == before
+
+    def test_scoped_action_fresh_db_is_structured_unavailable(self, tmp_path: Path) -> None:
+        vault = _make_vault(tmp_path)
+        for key in ("A", "B"):
+            _make_ocr_artifacts(vault, key)
+        _write_index(vault, [_entry("A", "A"), _entry("B", "B")])
+        rc, payload = _run_cli(
+            "--vault", str(vault), "action", "run", "memory.build",
+            "--scope", "papers", "--key", "A", "--json",
+        )
+        assert rc == 1
+        assert payload["error"]["code"] == "action.unavailable"
+
+
 class TestRegistryAndCli:
     def test_action_unknown_key_is_exit_2(self, tmp_path: Path) -> None:
         vault = _three_paper_vault(tmp_path)


### PR DESCRIPTION
## T4 corrective (review of #185)

### P0-3 — write_vector_lineage paper_ids shadow bug
The parameter was overwritten by `paper_ids = _papers_with_vectors(conn)`, making the filter恒真 — every vector paper with a manifest got rewritten (exactly the #165-pinned violation). The eligible set now derives from the connection and the parameter filters it. Direct unit test: A rewrites while B/C (with valid manifests) stay byte-identical — the old integration test only passed because B/C had no manifests.

### P0-4 — resume downgrade routing
`requested_resume` is preserved separately from the gate-downgraded effective `resume`; `_force_rebuild = force or (requested and not effective)`. The old expression's second clause was always False (True and False), silently degrading resume-reset paths (stale recovery / no rows / model change) to in-place builds. Regression: resume=True + stale-recovery downgrade routes the unscoped build through shadow (`ShadowBuild.prepare` observed); the same request papers-scoped fails before any mutation.

### Tests (3 new + hardened fixtures)
- direct `paper_ids={"A"}` unit test (B/C byte-identical, manifests present)
- B/C fixtures now carry valid manifests in the integration test
- unscoped resume-reset routes shadow; scoped resume-reset fails fast

### Evidence
- Python **3047 passed / 296 skipped**; ruff clean

Closes: #165.